### PR TITLE
Add PHP converter with lossless round-trip support

### DIFF
--- a/packages/typediagram/src/converters/index.ts
+++ b/packages/typediagram/src/converters/index.ts
@@ -7,5 +7,6 @@ export { csharp } from "./csharp.js";
 export { fsharp } from "./fsharp.js";
 export { dart } from "./dart.js";
 export { protobuf } from "./protobuf.js";
+export { php } from "./php.js";
 export { parseTypeRef, printTypeRef } from "./parse-typeref.js";
 export type { Converter, Language } from "./types.js";

--- a/packages/typediagram/src/converters/php.ts
+++ b/packages/typediagram/src/converters/php.ts
@@ -226,9 +226,7 @@ const renderConstructor = (params: readonly RenderedParam[], bodyLines: readonly
     .filter((param): param is RenderedParam & { docType: string } => param.docType !== null)
     .map((param) => `@param ${param.docType} $${param.name}`);
   const renderedDoc = renderDocblock(docLines, "    ");
-  const renderedParams = params.map(
-    (param) => `        public ${param.nativeType} $${param.name},`
-  );
+  const renderedParams = params.map((param) => `        public ${param.nativeType} $${param.name},`);
 
   if (bodyLines.length === 0) {
     return [

--- a/packages/typediagram/src/converters/php.ts
+++ b/packages/typediagram/src/converters/php.ts
@@ -1,0 +1,564 @@
+// [CONV-PHP] PHP DTO <-> typeDiagram bidirectional converter.
+import type { Diagnostic } from "../parser/diagnostics.js";
+import { type Result, err } from "../result.js";
+import type { Model, ResolvedTypeRef } from "../model/types.js";
+import { ModelBuilder, alias, record, union } from "../model/builder.js";
+import type { Converter } from "./types.js";
+import { parseTypeRef } from "./parse-typeref.js";
+
+const TD_TO_PHP_NATIVE: Record<string, string> = {
+  Bool: "bool",
+  Int: "int",
+  Float: "float",
+  String: "string",
+  Bytes: "string",
+  Unit: "null",
+};
+
+const TD_TO_PHP_DOC: Record<string, string> = {
+  Bool: "bool",
+  Int: "int",
+  Float: "float",
+  String: "string",
+  Bytes: "string",
+  Unit: "null",
+};
+
+const PHP_TO_TD: Record<string, string> = {
+  bool: "Bool",
+  int: "Int",
+  float: "Float",
+  string: "String",
+  null: "Unit",
+  void: "Unit",
+};
+
+const NO_SUPPORTED_DEFINITIONS: Diagnostic[] = [
+  {
+    severity: "error",
+    message: "No supported PHP DTO definitions found",
+    line: 0,
+    col: 0,
+    length: 0,
+  },
+];
+
+interface PhpTypeSpec {
+  nativeType: string;
+  docType: string | null;
+}
+
+interface RenderedParam extends PhpTypeSpec {
+  name: string;
+}
+
+type ParsedParam = RenderedParam;
+
+interface ParsedInterface {
+  declType: "interface";
+  name: string;
+  docblock: string | null;
+  body: string;
+}
+
+interface ParsedClass {
+  declType: "class";
+  name: string;
+  docblock: string | null;
+  body: string;
+  implementsName: string | null;
+}
+
+type ParsedDecl = ParsedInterface | ParsedClass;
+
+const isOptionType = (type: ResolvedTypeRef) => type.name === "Option" && type.args[0] !== undefined;
+
+const unwrapOptionType = (type: ResolvedTypeRef) => type.args[0] ?? type;
+
+const usesGenericType = (type: ResolvedTypeRef, generics: ReadonlySet<string>): boolean =>
+  generics.has(type.name) || type.args.some((arg) => usesGenericType(arg, generics));
+
+const adjustDepth = (depth: number, char: string, openChar: string, closeChar: string) => {
+  if (char === openChar) {
+    return depth + 1;
+  }
+  if (char === closeChar) {
+    return depth - 1;
+  }
+  return depth;
+};
+
+interface PhpScanState {
+  depth: number;
+  quote: '"' | "'" | null;
+  escaping: boolean;
+  lineComment: boolean;
+  blockComment: boolean;
+}
+
+const DEFAULT_SCAN_STATE: PhpScanState = {
+  depth: 0,
+  quote: null,
+  escaping: false,
+  lineComment: false,
+  blockComment: false,
+};
+
+const advancePhpScanState = (
+  source: string,
+  index: number,
+  state: PhpScanState,
+  openChar: string,
+  closeChar: string
+): PhpScanState => {
+  const char = source.charAt(index);
+  const nextChar = source.charAt(index + 1);
+  if (state.lineComment) {
+    return char === "\n" ? { ...state, lineComment: false } : state;
+  }
+  if (state.blockComment) {
+    return char === "*" && nextChar === "/" ? { ...state, blockComment: false } : state;
+  }
+  if (state.quote !== null) {
+    if (state.escaping) {
+      return { ...state, escaping: false };
+    }
+    if (char === "\\") {
+      return { ...state, escaping: true };
+    }
+    return char === state.quote ? { ...state, quote: null } : state;
+  }
+  if (char === "/" && nextChar === "/") {
+    return { ...state, lineComment: true };
+  }
+  if (char === "/" && nextChar === "*") {
+    return { ...state, blockComment: true };
+  }
+  if (char === '"' || char === "'") {
+    return { ...state, quote: char, escaping: false };
+  }
+  return { ...state, depth: adjustDepth(state.depth, char, openChar, closeChar) };
+};
+
+const splitTopLevel = (source: string, openChar: string, closeChar: string): string[] => {
+  const parts: string[] = [];
+  let state = DEFAULT_SCAN_STATE;
+  let start = 0;
+  for (let i = 0; i < source.length; i++) {
+    state = advancePhpScanState(source, i, state, openChar, closeChar);
+    if (
+      source.charAt(i) === "," &&
+      state.depth === 0 &&
+      state.quote === null &&
+      !state.lineComment &&
+      !state.blockComment
+    ) {
+      const part = source.slice(start, i).trim();
+      if (part.length > 0) {
+        parts.push(part);
+      }
+      start = i + 1;
+    }
+  }
+  const last = source.slice(start).trim();
+  return last.length > 0 ? [...parts, last] : parts;
+};
+
+const splitGenericArgs = (source: string) => splitTopLevel(source, "<", ">");
+
+const splitParams = (source: string) => splitTopLevel(source, "(", ")");
+
+const mapTdToPhpDocType = (type: ResolvedTypeRef): string => {
+  if (type.name === "List" && type.args[0] !== undefined) {
+    return `list<${mapTdToPhpDocType(type.args[0])}>`;
+  }
+  if (type.name === "Map" && type.args[0] !== undefined && type.args[1] !== undefined) {
+    return `array<${mapTdToPhpDocType(type.args[0])}, ${mapTdToPhpDocType(type.args[1])}>`;
+  }
+  if (type.name === "Option" && type.args[0] !== undefined) {
+    return `${mapTdToPhpDocType(type.args[0])}|null`;
+  }
+  return TD_TO_PHP_DOC[type.name] ?? type.name;
+};
+
+const getBasePhpTypeSpec = (type: ResolvedTypeRef, generics: ReadonlySet<string>): PhpTypeSpec => {
+  if (generics.has(type.name)) {
+    return { nativeType: "mixed", docType: type.name };
+  }
+  if (type.name === "List" || type.name === "Map") {
+    return { nativeType: "array", docType: mapTdToPhpDocType(type) };
+  }
+  if (type.name === "Unit") {
+    return { nativeType: "null", docType: null };
+  }
+  return { nativeType: TD_TO_PHP_NATIVE[type.name] ?? type.name, docType: null };
+};
+
+const getPhpTypeSpec = (type: ResolvedTypeRef, generics: ReadonlySet<string>): PhpTypeSpec => {
+  if (!isOptionType(type)) {
+    return getBasePhpTypeSpec(type, generics);
+  }
+  const inner = unwrapOptionType(type);
+  if (generics.has(inner.name)) {
+    return { nativeType: "mixed", docType: `${inner.name}|null` };
+  }
+  if (inner.name === "Unit") {
+    return { nativeType: "null", docType: null };
+  }
+  const base = getBasePhpTypeSpec(inner, generics);
+  if (base.nativeType === "array") {
+    return { nativeType: "?array", docType: `${mapTdToPhpDocType(inner)}|null` };
+  }
+  if (base.nativeType === "mixed") {
+    return { nativeType: "mixed", docType: `${mapTdToPhpDocType(inner)}|null` };
+  }
+  return {
+    nativeType: `?${base.nativeType}`,
+    docType: base.docType === null ? null : `${base.docType}|null`,
+  };
+};
+
+const renderDocblock = (lines: readonly string[], indent = "") =>
+  lines.length === 0 ? [] : [`${indent}/**`, ...lines.map((line) => `${indent} * ${line}`), `${indent} */`];
+
+const renderConstructor = (params: readonly RenderedParam[], bodyLines: readonly string[]) => {
+  const docLines = params
+    .filter((param): param is RenderedParam & { docType: string } => param.docType !== null)
+    .map((param) => `@param ${param.docType} $${param.name}`);
+  const renderedDoc = renderDocblock(docLines, "    ");
+  const renderedParams = params.map(
+    (param) => `        public ${param.nativeType} $${param.name},`
+  );
+
+  if (bodyLines.length === 0) {
+    return [
+      ...renderedDoc,
+      ...(renderedParams.length === 0
+        ? ["    public function __construct() {}"]
+        : ["    public function __construct(", ...renderedParams, "    ) {}"]),
+    ];
+  }
+
+  return [
+    ...renderedDoc,
+    ...(renderedParams.length === 0
+      ? ["    public function __construct()"]
+      : ["    public function __construct(", ...renderedParams, "    )"]),
+    "    {",
+    ...bodyLines.map((line) => `        ${line}`),
+    "    }",
+  ];
+};
+
+const renderRecord = (
+  name: string,
+  generics: readonly string[],
+  fields: readonly { name: string; type: ResolvedTypeRef }[]
+) => {
+  const genericSet = new Set(generics);
+  const params = fields.map((field) => ({ name: field.name, ...getPhpTypeSpec(field.type, genericSet) }));
+  return [
+    ...renderDocblock(generics.map((generic) => `@template ${generic}`)),
+    `final readonly class ${name}`,
+    "{",
+    ...renderConstructor(params, []),
+    "}",
+  ].join("\n");
+};
+
+const renderUnion = (
+  name: string,
+  generics: readonly string[],
+  variants: readonly { name: string; fields: readonly { name: string; type: ResolvedTypeRef }[] }[]
+) => {
+  const genericSet = new Set(generics);
+  const blocks: string[] = [
+    [...renderDocblock(generics.map((generic) => `@template ${generic}`)), `interface ${name}`, "{", "}"].join("\n"),
+  ];
+
+  for (const variant of variants) {
+    const variantUsesGeneric = variant.fields.some((field) => usesGenericType(field.type, genericSet));
+    const params = variant.fields.map((field) => ({
+      name: field.name,
+      ...getPhpTypeSpec(field.type, genericSet),
+    }));
+    const classDoc = variantUsesGeneric
+      ? renderDocblock([
+          ...generics.map((generic) => `@template ${generic}`),
+          `@implements ${name}<${generics.join(", ")}>`,
+        ])
+      : [];
+    blocks.push(
+      [
+        ...classDoc,
+        `final readonly class ${variant.name} implements ${name}`,
+        "{",
+        `    /** @var '${variant.name}' */`,
+        "    public string $kind;",
+        "",
+        ...renderConstructor(params, [`$this->kind = '${variant.name}';`]),
+        "}",
+      ].join("\n")
+    );
+  }
+
+  return blocks;
+};
+
+const renderAlias = (name: string, generics: readonly string[], target: ResolvedTypeRef) => {
+  const params = [{ name: "value", ...getPhpTypeSpec(target, new Set(generics)) }];
+  return [
+    ...renderDocblock([...generics.map((generic) => `@template ${generic}`), "@typediagram-kind alias"]),
+    `final readonly class ${name}`,
+    "{",
+    ...renderConstructor(params, []),
+    "}",
+  ].join("\n");
+};
+
+const toPhp = (model: Model): string => {
+  const blocks = model.decls.flatMap((decl) => {
+    if (decl.kind === "record") {
+      return [renderRecord(decl.name, decl.generics, decl.fields)];
+    }
+    if (decl.kind === "union") {
+      return renderUnion(decl.name, decl.generics, decl.variants);
+    }
+    return [renderAlias(decl.name, decl.generics, decl.target)];
+  });
+  return [
+    "<?php",
+    "",
+    "declare(strict_types=1);",
+    "",
+    ...blocks.flatMap((block, index) => (index === 0 ? [block] : ["", block])),
+    "",
+  ].join("\n");
+};
+
+const findMatchingDelimiter = (source: string, openIndex: number, openChar: string, closeChar: string) => {
+  let state = DEFAULT_SCAN_STATE;
+  for (let index = openIndex; index < source.length; index++) {
+    state = advancePhpScanState(source, index, state, openChar, closeChar);
+    if (state.depth === 0 && state.quote === null && !state.lineComment && !state.blockComment) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+const extractDocblockBeforeOffset = (source: string, offset: number) => {
+  const prefix = source.slice(0, offset).replace(/\s+$/, "");
+  if (!prefix.endsWith("*/")) {
+    return null;
+  }
+  const start = prefix.lastIndexOf("/**");
+  return start === -1 ? null : prefix.slice(start);
+};
+
+const parseTemplatesFromDocblock = (docblock: string | null) =>
+  [...(docblock?.matchAll(/@template\s+([A-Za-z_][A-Za-z0-9_]*)/g) ?? [])].flatMap((match) =>
+    match[1] === undefined ? [] : [match[1]]
+  );
+
+const parseParamDocsFromDocblock = (docblock: string | null) =>
+  new Map(
+    [...(docblock?.matchAll(/@param\s+(.+?)\s+\$(\w+)/g) ?? [])].flatMap((match) =>
+      match[1] === undefined || match[2] === undefined ? [] : [[match[2], match[1]] as const]
+    )
+  );
+
+const parseDeclarations = (source: string): ParsedDecl[] => {
+  const declarations: ParsedDecl[] = [];
+  const declarationRe = /interface\s+(\w+)\s*\{|final readonly class\s+(\w+)(?:\s+implements\s+(\w+))?\s*\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = declarationRe.exec(source)) !== null) {
+    const [, interfaceName, className, implementsName] = match;
+    const openIndex = source.indexOf("{", match.index);
+    const closeIndex = findMatchingDelimiter(source, openIndex, "{", "}");
+    if (closeIndex === -1) {
+      continue;
+    }
+    const body = source.slice(openIndex + 1, closeIndex);
+    const docblock = extractDocblockBeforeOffset(source, match.index);
+    declarations.push(
+      interfaceName !== undefined
+        ? { declType: "interface", name: interfaceName, docblock, body }
+        : { declType: "class", name: className ?? "", docblock, body, implementsName: implementsName ?? null }
+    );
+    declarationRe.lastIndex = closeIndex + 1;
+  }
+  return declarations;
+};
+
+const parseParams = (source: string, constructorDoc: string | null): ParsedParam[] => {
+  const docTypes = parseParamDocsFromDocblock(constructorDoc);
+  return splitParams(source)
+    .map((part) => {
+      const trimmed = part.trim();
+      if (!trimmed.startsWith("public ")) {
+        return null;
+      }
+      const afterPublic = trimmed.slice("public ".length).trimStart();
+      const dollarIndex = afterPublic.indexOf("$");
+      if (dollarIndex === -1) {
+        return null;
+      }
+      const nativeType = afterPublic.slice(0, dollarIndex).trim();
+      const name = /^(\w+)/.exec(afterPublic.slice(dollarIndex + 1))?.[1];
+      return nativeType.length === 0 || name === undefined
+        ? null
+        : {
+            name,
+            nativeType,
+            docType: docTypes.get(name) ?? null,
+          };
+    })
+    .filter((param): param is ParsedParam => param !== null);
+};
+
+const parseConstructor = (body: string) => {
+  const start = body.indexOf("public function __construct(");
+  if (start === -1) {
+    return { params: [] as ParsedParam[], body: "" };
+  }
+  const constructorDoc = extractDocblockBeforeOffset(body, start);
+  const openParen = body.indexOf("(", start);
+  const closeParen = findMatchingDelimiter(body, openParen, "(", ")");
+  const openBrace = body.indexOf("{", closeParen);
+  const closeBrace = findMatchingDelimiter(body, openBrace, "{", "}");
+  return {
+    params: parseParams(body.slice(openParen + 1, closeParen), constructorDoc),
+    body: body.slice(openBrace + 1, closeBrace).trim(),
+  };
+};
+
+const mapPhpNativeTypeToTd = (nativeType: string): string => {
+  const trimmed = nativeType.trim();
+  if (trimmed.startsWith("?")) {
+    return `Option<${mapPhpNativeTypeToTd(trimmed.slice(1))}>`;
+  }
+  return PHP_TO_TD[trimmed] ?? trimmed;
+};
+
+const mapPhpDocTypeToTd = (docType: string): string => {
+  const trimmed = docType.trim();
+  if (trimmed.endsWith("|null")) {
+    return `Option<${mapPhpDocTypeToTd(trimmed.slice(0, -5))}>`;
+  }
+  if (trimmed.startsWith("list<") && trimmed.endsWith(">")) {
+    return `List<${mapPhpDocTypeToTd(trimmed.slice(5, -1))}>`;
+  }
+  if (trimmed.startsWith("array<") && trimmed.endsWith(">")) {
+    const args = splitGenericArgs(trimmed.slice(6, -1));
+    // splitGenericArgs (via splitTopLevel) only produces non-empty strings, so
+    // index accesses are safe — the as-string casts replace unreachable undefined guards.
+    return args.length === 1
+      ? `List<${mapPhpDocTypeToTd(args[0] as string)}>`
+      : args.length === 2
+        ? `Map<${mapPhpDocTypeToTd(args[0] as string)}, ${mapPhpDocTypeToTd(args[1] as string)}>`
+        : "Map<String, String>";
+  }
+  return PHP_TO_TD[trimmed] ?? trimmed;
+};
+
+const toTypeRef = (param: ParsedParam) =>
+  parseTypeRef(param.docType === null ? mapPhpNativeTypeToTd(param.nativeType) : mapPhpDocTypeToTd(param.docType));
+
+const parseKindLiteral = (body: string) => {
+  const propertyIndex = body.indexOf("public string $kind;");
+  const varIndex = body.indexOf("@var ");
+  if (propertyIndex === -1 || varIndex === -1 || varIndex > propertyIndex) {
+    return null;
+  }
+  const literalStart = varIndex + "@var ".length;
+  const quote = body.charAt(literalStart);
+  if (quote !== "'" && quote !== '"') {
+    return null;
+  }
+  const close = body.indexOf(quote, literalStart + 1);
+  return close === -1 ? null : body.slice(literalStart + 1, close);
+};
+
+const fromPhp = (source: string): Result<Model, Diagnostic[]> => {
+  const declarations = parseDeclarations(source);
+  const interfaces = new Map(
+    declarations
+      .filter((decl): decl is ParsedInterface => decl.declType === "interface")
+      .map((decl) => [decl.name, decl] as const)
+  );
+  const variantMap = new Map<string, Array<{ name: string; fields: Array<{ name: string; type: ResolvedTypeRef }> }>>();
+  const variantNames = new Set<string>();
+
+  for (const declaration of declarations) {
+    if (
+      declaration.declType !== "class" ||
+      declaration.implementsName === null ||
+      !interfaces.has(declaration.implementsName)
+    ) {
+      continue;
+    }
+    const kindLiteral = parseKindLiteral(declaration.body);
+    if (kindLiteral !== declaration.name) {
+      continue;
+    }
+    const constructor = parseConstructor(declaration.body);
+    variantNames.add(declaration.name);
+    variantMap.set(declaration.implementsName, [
+      ...(variantMap.get(declaration.implementsName) ?? []),
+      {
+        name: declaration.name,
+        fields: constructor.params.map((param) => ({ name: param.name, type: toTypeRef(param) })),
+      },
+    ]);
+  }
+
+  const builder = new ModelBuilder();
+  let found = false;
+
+  for (const declaration of declarations) {
+    if (declaration.declType === "interface") {
+      const variants = variantMap.get(declaration.name);
+      if (variants === undefined) {
+        continue;
+      }
+      found = true;
+      builder.add(union(declaration.name, variants, parseTemplatesFromDocblock(declaration.docblock)));
+      continue;
+    }
+
+    if (variantNames.has(declaration.name)) {
+      continue;
+    }
+
+    const constructor = parseConstructor(declaration.body);
+    const generics = parseTemplatesFromDocblock(declaration.docblock);
+    const isAlias = /@typediagram-kind\s+alias/.test(declaration.docblock ?? "");
+    if (isAlias) {
+      const valueParam = constructor.params[0];
+      if (valueParam?.name !== "value") {
+        continue;
+      }
+      found = true;
+      builder.add(alias(declaration.name, toTypeRef(valueParam), generics));
+      continue;
+    }
+
+    found = true;
+    builder.add(
+      record(
+        declaration.name,
+        constructor.params.map((param) => ({ name: param.name, type: toTypeRef(param) })),
+        generics
+      )
+    );
+  }
+
+  return found ? builder.build() : err(NO_SUPPORTED_DEFINITIONS);
+};
+
+export const php: Converter = {
+  language: "php",
+  fromSource: fromPhp,
+  toSource: toPhp,
+};

--- a/packages/typediagram/src/converters/types.ts
+++ b/packages/typediagram/src/converters/types.ts
@@ -3,7 +3,7 @@ import type { Diagnostic } from "../parser/diagnostics.js";
 import type { Result } from "../result.js";
 import type { Model } from "../model/types.js";
 
-export type Language = "typescript" | "python" | "rust" | "go" | "csharp" | "fsharp" | "dart" | "protobuf";
+export type Language = "typescript" | "python" | "rust" | "go" | "csharp" | "fsharp" | "dart" | "protobuf" | "php";
 
 export interface PythonOpts {
   readonly style?: "dataclass" | "pydantic";

--- a/packages/typediagram/test/converters/php.test.ts
+++ b/packages/typediagram/test/converters/php.test.ts
@@ -1,0 +1,384 @@
+// [CONV-PHP-TEST] PHP converter integration tests.
+import { describe, expect, it } from "vitest";
+import { php } from "../../src/converters/index.js";
+import { parse } from "../../src/parser/index.js";
+import { buildModel } from "../../src/model/index.js";
+import { expectLosslessRoundTrip, unwrap } from "./helpers.js";
+
+describe("[CONV-PHP-TO-COMPLEX] complex typeDiagram -> PHP", () => {
+  it("emits readonly DTOs, PHPStan refinements, unions, and alias wrappers", () => {
+    const td = `
+type User {
+  id: Int
+  name: String
+}
+
+type Box<T> {
+  value: T
+}
+
+type Paged {
+  items: List<String>
+}
+
+type Config {
+  data: Map<String, Int>
+}
+
+type Opt {
+  label: Option<String>
+}
+
+type MaybeBox<T> {
+  value: Option<T>
+}
+
+union Shape {
+  Circle { radius: Float }
+  Rectangle { width: Float, height: Float }
+}
+
+union Result<T> {
+  Ok { value: T }
+  Err { message: String }
+}
+
+alias UserId = Int
+alias Boxed<T> = T
+alias Nothing = Unit
+
+type MaybeNothing {
+  value: Option<Unit>
+}
+`;
+    const model = unwrap(buildModel(unwrap(parse(td))));
+    const output = php.toSource(model);
+
+    expect(output).toContain("<?php");
+    expect(output).toContain("declare(strict_types=1);");
+    expect(output).toContain("final readonly class User");
+    expect(output).toContain("public int $id");
+    expect(output).toContain("public string $name");
+    expect(output).toContain("@template T");
+    expect(output).toContain("public mixed $value");
+    expect(output).toContain("@param T $value");
+    expect(output).toContain("public array $items");
+    expect(output).toContain("@param list<string> $items");
+    expect(output).toContain("@param array<string, int> $data");
+    expect(output).toContain("public ?string $label");
+    expect(output).toContain("@param T|null $value");
+    expect(output).toContain("interface Shape");
+    expect(output).toContain("final readonly class Circle implements Shape");
+    expect(output).toContain("final readonly class Rectangle implements Shape");
+    expect(output).toContain("/** @var 'Circle' */");
+    expect(output).toContain("/** @var 'Rectangle' */");
+    expect(output).toContain("$this->kind = 'Circle';");
+    expect(output).toContain("$this->kind = 'Rectangle';");
+    expect(output).toContain("@implements Result<T>");
+    expect(output).toContain("@typediagram-kind alias");
+    expect(output).toContain("final readonly class UserId");
+    expect(output).toContain("final readonly class Nothing");
+    expect(output).toContain("final readonly class MaybeNothing");
+    expect(output).toContain("public null $value,");
+  });
+});
+
+describe("[CONV-PHP-FROM] PHP -> typeDiagram", () => {
+  it("parses alias-only PHP DTO input", () => {
+    const src = `<?php
+
+declare(strict_types=1);
+
+/**
+ * @template T
+ * @typediagram-kind alias
+ */
+final readonly class Boxed
+{
+    /**
+     * @param T $value
+     */
+    public function __construct(
+        public mixed $value,
+    ) {}
+}
+`;
+    const model = unwrap(php.fromSource(src));
+    const boxed = model.decls.find((decl) => decl.name === "Boxed");
+
+    expect(boxed?.kind).toBe("alias");
+    expect(boxed?.generics).toEqual(["T"]);
+    expect(boxed?.kind === "alias" ? boxed.target.name : "").toBe("T");
+  });
+
+  it("returns an error when no supported DTO definitions are present", () => {
+    const src = `<?php
+
+declare(strict_types=1);
+
+function helper(): void {}
+`;
+    const result = php.fromSource(src);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.error[0]?.message).toBe("No supported PHP DTO definitions found");
+  });
+  it("parses refined arrays, ignores empty interfaces, and skips broken alias wrappers", () => {
+    const src = `<?php
+
+declare(strict_types=1);
+
+interface Flag
+{
+}
+
+final readonly class MissingKind implements Flag
+{
+    public function __construct() {}
+}
+
+final readonly class Mapping
+{
+    /**
+     * @param array<string, int> $data
+     * @param list<string>|null $labels
+     */
+    public function __construct(
+        public array $data,
+        public ?array $labels = null,
+    ) {}
+}
+
+/** @typediagram-kind alias */
+final readonly class BrokenAlias
+{
+    public function __construct(
+        public int $id,
+    ) {}
+}
+
+final readonly class NoCtor
+{
+}
+`;
+    const model = unwrap(php.fromSource(src));
+    const mapping = model.decls.find((decl) => decl.name === "Mapping");
+    const missingKind = model.decls.find((decl) => decl.name === "MissingKind");
+    const noCtor = model.decls.find((decl) => decl.name === "NoCtor");
+
+    expect(model.decls.find((decl) => decl.name === "Flag")).toBeUndefined();
+    expect(model.decls.find((decl) => decl.name === "BrokenAlias")).toBeUndefined();
+    expect(mapping?.kind).toBe("record");
+    expect(mapping?.kind === "record" ? mapping.fields[0]?.type.name : "").toBe("Map");
+    expect(mapping?.kind === "record" ? mapping.fields[0]?.type.args[0]?.name : "").toBe("String");
+    expect(mapping?.kind === "record" ? mapping.fields[0]?.type.args[1]?.name : "").toBe("Int");
+    expect(mapping?.kind === "record" ? mapping.fields[1]?.type.name : "").toBe("Option");
+    expect(mapping?.kind === "record" ? mapping.fields[1]?.type.args[0]?.name : "").toBe("List");
+    expect(mapping?.kind === "record" ? mapping.fields[1]?.type.args[0]?.args[0]?.name : "").toBe("String");
+    expect(missingKind?.kind).toBe("record");
+    expect(missingKind?.kind === "record" ? missingKind.fields : []).toHaveLength(0);
+    expect(noCtor?.kind).toBe("record");
+    expect(noCtor?.kind === "record" ? noCtor.fields : []).toHaveLength(0);
+  });
+
+  it("parses namespaced types, array item docblocks, double-quoted kind tags, and defaults with commas", () => {
+    const src = `<?php
+
+declare(strict_types=1);
+
+interface Outcome
+{
+}
+
+final readonly class Success implements Outcome
+{
+    /** @var "Success" */
+    public string $kind;
+
+    public function __construct(
+        public string $message = "Hello, world" /* keep, comment */,
+        public \\App\\DTO\\User $user,
+    ) {
+        $this->kind = "Success";
+    }
+}
+
+final readonly class CollectionHolder
+{
+    /**
+     * @param array<\\App\\DTO\\User> $users
+     */
+    public function __construct(
+        public array $users,
+    ) {}
+}
+`;
+    const model = unwrap(php.fromSource(src));
+    const outcome = model.decls.find((decl) => decl.name === "Outcome");
+    const holder = model.decls.find((decl) => decl.name === "CollectionHolder");
+
+    expect(outcome?.kind).toBe("union");
+    expect(outcome?.kind === "union" ? outcome.variants.length : 0).toBe(1);
+    expect(outcome?.kind === "union" ? outcome.variants[0]?.name : "").toBe("Success");
+    expect(outcome?.kind === "union" ? outcome.variants[0]?.fields[0]?.name : "").toBe("message");
+    expect(outcome?.kind === "union" ? outcome.variants[0]?.fields[0]?.type.name : "").toBe("String");
+    expect(outcome?.kind === "union" ? outcome.variants[0]?.fields[1]?.type.name : "").toBe("\\App\\DTO\\User");
+    expect(holder?.kind).toBe("record");
+    expect(holder?.kind === "record" ? holder.fields[0]?.type.name : "").toBe("List");
+    expect(holder?.kind === "record" ? holder.fields[0]?.type.args[0]?.name : "").toBe("\\App\\DTO\\User");
+  });
+});
+
+describe("[CONV-PHP-RT] PHP round-trip TD -> PHP -> TD", () => {
+  it("round-trips records, unions, aliases, generics, and refined arrays preserving structure", () => {
+    const td = `
+type User {
+  id: Int
+  tags: List<String>
+  label: Option<String>
+}
+
+type Box<T> {
+  value: T
+}
+
+union Result<T> {
+  Ok { value: T }
+  Err { message: String }
+}
+
+alias UserId = Int
+alias Boxed<T> = T
+alias Nothing = Unit
+
+type MaybeNothing {
+  value: Option<Unit>
+}
+`;
+    const model1 = unwrap(buildModel(unwrap(parse(td))));
+    const phpCode = php.toSource(model1);
+    const model2 = unwrap(php.fromSource(phpCode));
+
+    const user = model2.decls.find((decl) => decl.name === "User");
+    expect(user?.kind).toBe("record");
+    expect(user?.kind === "record" ? user.fields.length : 0).toBe(3);
+    expect(user?.kind === "record" ? user.fields[0]?.type.name : "").toBe("Int");
+    expect(user?.kind === "record" ? user.fields[1]?.type.name : "").toBe("List");
+    expect(user?.kind === "record" ? user.fields[1]?.type.args[0]?.name : "").toBe("String");
+    expect(user?.kind === "record" ? user.fields[2]?.type.name : "").toBe("Option");
+    expect(user?.kind === "record" ? user.fields[2]?.type.args[0]?.name : "").toBe("String");
+
+    const box = model2.decls.find((decl) => decl.name === "Box");
+    expect(box?.kind).toBe("record");
+    expect(box?.generics).toEqual(["T"]);
+    expect(box?.kind === "record" ? box.fields[0]?.type.name : "").toBe("T");
+
+    const result = model2.decls.find((decl) => decl.name === "Result");
+    expect(result?.kind).toBe("union");
+    expect(result?.generics).toEqual(["T"]);
+    expect(result?.kind === "union" ? result.variants.length : 0).toBe(2);
+    expect(result?.kind === "union" ? result.variants[0]?.name : "").toBe("Ok");
+    expect(result?.kind === "union" ? result.variants[0]?.fields[0]?.type.name : "").toBe("T");
+    expect(result?.kind === "union" ? result.variants[1]?.name : "").toBe("Err");
+    expect(result?.kind === "union" ? result.variants[1]?.fields[0]?.type.name : "").toBe("String");
+
+    const userId = model2.decls.find((decl) => decl.name === "UserId");
+    expect(userId?.kind).toBe("alias");
+    expect(userId?.kind === "alias" ? userId.target.name : "").toBe("Int");
+
+    const boxed = model2.decls.find((decl) => decl.name === "Boxed");
+    expect(boxed?.kind).toBe("alias");
+    expect(boxed?.generics).toEqual(["T"]);
+    expect(boxed?.kind === "alias" ? boxed.target.name : "").toBe("T");
+  });
+
+  it("losslessly round-trips the home-page example through PHP (TD text preserved)", () => {
+    expectLosslessRoundTrip(php);
+  });
+});
+
+describe("[CONV-PHP-EDGE] PHP converter edge cases", () => {
+  it("emits an empty constructor for records with no fields", () => {
+    const td = `type Empty {}\n`;
+    const model = unwrap(buildModel(unwrap(parse(td))));
+    const output = php.toSource(model);
+    expect(output).toContain("public function __construct() {}");
+    expect(unwrap(php.fromSource(output)).decls.find((d) => d.name === "Empty")?.kind).toBe("record");
+  });
+
+  it("round-trips Option<List<T>> and Option<Map<K,V>>", () => {
+    // Note: Option<Unit> is NOT round-trippable because both Unit and
+    // Option<Unit> map to PHP `null` native type with no docblock — the
+    // nullability information is indistinguishable on parse. HOME_PAGE_SAMPLE
+    // does not use Option<Unit>, so the lossless test above still holds.
+    const td = `type Wrap {
+  ids: Option<List<Int>>
+  dict: Option<Map<String, Int>>
+}
+`;
+    const code = php.toSource(unwrap(buildModel(unwrap(parse(td)))));
+    expect(code).toContain("public ?array $ids");
+    expect(code).toContain("@param list<int>|null $ids");
+    expect(code).toContain("@param array<string, int>|null $dict");
+    const wrap = unwrap(php.fromSource(code)).decls.find((d) => d.name === "Wrap");
+    expect(wrap?.kind).toBe("record");
+    if (wrap?.kind !== "record") return;
+    expect(wrap.fields[0]?.type.name).toBe("Option");
+    expect(wrap.fields[0]?.type.args[0]?.name).toBe("List");
+    expect(wrap.fields[1]?.type.args[0]?.name).toBe("Map");
+  });
+
+  it("skips constructor params without the 'public' promotion keyword", () => {
+    const src = `<?php
+final readonly class Odd
+{
+    public function __construct(
+        private int $hidden,
+        public int $ok,
+    ) {}
+}
+`;
+    const odd = unwrap(php.fromSource(src)).decls.find((d) => d.name === "Odd");
+    expect(odd?.kind).toBe("record");
+    expect(odd?.kind === "record" ? odd.fields.map((f) => f.name) : []).toEqual(["ok"]);
+  });
+
+  it("tolerates // and /* */ comments and string literals inside class bodies", () => {
+    const src = `<?php
+final readonly class Commented
+{
+    // public int $ignored;
+    /* public int $alsoIgnored; */
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {
+        $greeting = "hello { ' } world";
+    }
+}
+`;
+    const commented = unwrap(php.fromSource(src)).decls.find((d) => d.name === "Commented");
+    expect(commented?.kind === "record" ? commented.fields.map((f) => f.name) : []).toEqual(["name", "age"]);
+  });
+
+  it("drops union variants whose $kind literal does not match the class name", () => {
+    const src = `<?php
+interface Shape
+{
+}
+
+final readonly class Circle implements Shape
+{
+    /** @var 'NotCircle' */
+    public string $kind;
+    public function __construct(
+        public float $radius,
+    ) {
+        $this->kind = 'NotCircle';
+    }
+}
+`;
+    const model = unwrap(php.fromSource(src));
+    expect(model.decls.find((d) => d.name === "Shape")).toBeUndefined();
+  });
+});

--- a/packages/typediagram/test/converters/php.test.ts
+++ b/packages/typediagram/test/converters/php.test.ts
@@ -322,7 +322,9 @@ describe("[CONV-PHP-EDGE] PHP converter edge cases", () => {
     expect(code).toContain("@param array<string, int>|null $dict");
     const wrap = unwrap(php.fromSource(code)).decls.find((d) => d.name === "Wrap");
     expect(wrap?.kind).toBe("record");
-    if (wrap?.kind !== "record") return;
+    if (wrap?.kind !== "record") {
+      return;
+    }
     expect(wrap.fields[0]?.type.name).toBe("Option");
     expect(wrap.fields[0]?.type.args[0]?.name).toBe("List");
     expect(wrap.fields[1]?.type.args[0]?.name).toBe("Map");

--- a/packages/web/src/converter-highlight.ts
+++ b/packages/web/src/converter-highlight.ts
@@ -106,6 +106,23 @@ const DART_RULES: readonly Rule[] = [
   { re: /[<>{}:;,=|?()[\]]/g, cls: "hl-punct" },
 ];
 
+const PHP_RULES: readonly Rule[] = [
+  { re: /\/\/.*$/gm, cls: "hl-comment" },
+  { re: /#.*$/gm, cls: "hl-comment" },
+  { re: /\/\*[\s\S]*?\*\//gm, cls: "hl-comment" },
+  {
+    re: /\b(class|interface|abstract|final|readonly|extends|implements|public|private|protected|static|function|new|return|namespace|use|const|enum|match|self|parent|this)\b/g,
+    cls: "hl-keyword",
+  },
+  {
+    re: /\b(bool|int|float|string|array|object|null|void|mixed|never|iterable|callable|true|false)\b/g,
+    cls: "hl-builtin",
+  },
+  { re: /\$[A-Za-z_][A-Za-z0-9_]*/g, cls: "hl-field" },
+  { re: /\b([A-Z][A-Za-z0-9_]*)\b/g, cls: "hl-type" },
+  { re: /[<>{}:;,=|?()[\]]/g, cls: "hl-punct" },
+];
+
 const PROTOBUF_RULES: readonly Rule[] = [
   { re: /\/\/.*$/gm, cls: "hl-comment" },
   { re: /\/\*[\s\S]*?\*\//gm, cls: "hl-comment" },
@@ -122,7 +139,7 @@ const PROTOBUF_RULES: readonly Rule[] = [
   { re: /[<>{}:;,=()[\]]/g, cls: "hl-punct" },
 ];
 
-type SupportedLang = "typescript" | "rust" | "python" | "go" | "csharp" | "fsharp" | "dart" | "protobuf";
+type SupportedLang = "typescript" | "rust" | "python" | "go" | "csharp" | "fsharp" | "dart" | "protobuf" | "php";
 
 const LANG_RULES: Record<SupportedLang, readonly Rule[]> = {
   typescript: TYPESCRIPT_RULES,
@@ -133,6 +150,7 @@ const LANG_RULES: Record<SupportedLang, readonly Rule[]> = {
   fsharp: FSHARP_RULES,
   dart: DART_RULES,
   protobuf: PROTOBUF_RULES,
+  php: PHP_RULES,
 };
 
 type Span = { start: number; end: number; cls: string };

--- a/packages/web/src/converter-render.ts
+++ b/packages/web/src/converter-render.ts
@@ -1,7 +1,7 @@
 // [WEB-CONV-RENDER] Pipeline: language source ↔ typeDiagram source + SVG.
 // Lazy-loads the typediagram module like render-pane.ts.
 
-export type SupportedLang = "typescript" | "python" | "rust" | "go" | "csharp" | "fsharp" | "dart" | "protobuf";
+export type SupportedLang = "typescript" | "python" | "rust" | "go" | "csharp" | "fsharp" | "dart" | "protobuf" | "php";
 
 const getTheme = () =>
   window.matchMedia("(prefers-color-scheme: dark)").matches ? ("dark" as const) : ("light" as const);
@@ -26,6 +26,7 @@ export const convertSource = async (source: string, lang: SupportedLang): Promis
     fsharp: converters.fsharp,
     dart: converters.dart,
     protobuf: converters.protobuf,
+    php: converters.php,
   } as const;
 
   const conv = converterMap[lang];
@@ -60,6 +61,7 @@ export const convertFromTd = async (tdSource: string, lang: SupportedLang): Prom
     fsharp: converters.fsharp,
     dart: converters.dart,
     protobuf: converters.protobuf,
+    php: converters.php,
   } as const;
 
   const parsed = parser.parse(tdSource);

--- a/packages/web/src/converter.ts
+++ b/packages/web/src/converter.ts
@@ -20,6 +20,7 @@ const LANG_LABELS: Record<SupportedLang, string> = {
   fsharp: "F#",
   dart: "Dart",
   protobuf: "Protobuf",
+  php: "PHP",
 };
 
 const LANGUAGES: readonly SupportedLang[] = [
@@ -31,6 +32,7 @@ const LANGUAGES: readonly SupportedLang[] = [
   "fsharp",
   "dart",
   "protobuf",
+  "php",
 ];
 
 const DEFAULT_LANG: SupportedLang = "typescript";


### PR DESCRIPTION
## TLDR

Adds a PHP DTO ↔ typeDiagram converter (8th language) that losslessly round-trips the canonical `HOME_PAGE_SAMPLE`, and wires PHP into the web converter playground.

## Details

### New
- `packages/typediagram/src/converters/php.ts` — 564-line converter emitting `final readonly class` DTOs with constructor-promoted `public` params, `declare(strict_types=1)`, PHPStan `@template` / `@param list<...>` / `@param array<K,V>` / `|null` docblocks, and sealed `interface` + implementing classes with `@var 'Kind'` tags for tagged unions. Parser supports nested generics, Option unwrapping, `@typediagram-kind alias` wrappers, and scan-state tracking for `//`, `/* */`, and string literals inside class bodies.
- `packages/typediagram/test/converters/php.test.ts` — 12 tests across four describe blocks: `[CONV-PHP-TO-COMPLEX]`, `[CONV-PHP-FROM]`, `[CONV-PHP-RT]`, and `[CONV-PHP-EDGE]`.
- PHP tab in the web playground — added to the `LANGUAGES` list, `LANG_LABELS`, highlight rules (`PHP_RULES` covering class/interface keywords, `?type` nullables, `$vars`, PHPDoc), and both `convertSource` / `convertFromTd` converter maps.

### Changed
- `converters/index.ts` exports `php`.
- `Language` union in `converters/types.ts` gains `"php"`.
- Web `SupportedLang` aligned across `converter.ts`, `converter-render.ts`, and `converter-highlight.ts`.

### Known lossless limitation
`Option<Unit>` is NOT round-trippable because both `Unit` and `Option<Unit>` collapse to PHP `null` native type with no docblock — the nullability is indistinguishable on parse. `HOME_PAGE_SAMPLE` does not use `Option<Unit>`, so the byte-for-byte round-trip test still holds. Documented inline in the edge-case test.

## How Do The Automated Tests Prove It Works?

- `[CONV-PHP-RT] losslessly round-trips the home-page example through PHP (TD text preserved)` — the canonical `expectLosslessRoundTrip(php)` assertion (identical pattern to the other 7 converters) confirms `TD → PHP → TD` is byte-for-byte identical, including field order (which required removing the `sortFields` Option-reordering hack in the emitter).
- `[CONV-PHP-TO-COMPLEX]` asserts specific emitted strings: `final readonly class`, `@template T`, `public ?string $label`, `@param list<string>`, `@param array<string, int>`, `interface Shape`, `@var 'Circle'`, `@implements Result<T>`, `@typediagram-kind alias`.
- `[CONV-PHP-FROM]` covers alias-only parsing and the `NO_SUPPORTED_DEFINITIONS` error path.
- `[CONV-PHP-EDGE]` covers empty constructors, `Option<List<Int>>` / `Option<Map<String,Int>>` emission and parse, `private`-promoted params being skipped, inline `//` / `/* */` / string-literal tolerance, and `$kind` mismatch handling.
- Full suite: `make ci` green — **318 tests pass**, bundle 74.55 KB within 75 KB budget, coverage 95.17% lines / 91.2% branches (above 95 / 90.89 thresholds); php.ts specifically at 96.2% / 92.16%.

Co-authored with @voku (original PHP converter work from the `php` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)