### PR TITLE
Preflight unsupported VS Code runtimes before PDF export

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -16,10 +16,10 @@
       "lines": 96.71
     },
     "packages/web": {
-      "statements": 95.43,
+      "statements": 97.64864864864865,
       "branches": 95.86,
-      "functions": 97.63,
-      "lines": 95.43
+      "functions": 97.93617021276596,
+      "lines": 97.62306368330465
     },
     "packages/vscode": {
       "statements": 99,

--- a/packages/vscode/src/export-pdf.ts
+++ b/packages/vscode/src/export-pdf.ts
@@ -21,6 +21,7 @@ export interface ExportPdfDeps {
   readonly readFile: (uri: vscode.Uri) => Promise<Uint8Array>;
   readonly writeFile: (uri: vscode.Uri, data: Uint8Array) => Promise<void>;
   readonly uriWithPath: (base: vscode.Uri, newPath: string) => vscode.Uri;
+  readonly isPrintToPdfRuntimeSupported?: () => boolean;
   readonly createWebviewPanel: (
     viewType: string,
     title: string,
@@ -182,6 +183,8 @@ export function composeHtml(mdSource: string, opts: { theme: Theme; title: strin
 // ---------------------------------------------------------------------------
 
 const PRINT_LOAD_TIMEOUT_MS = 15_000;
+const UNSUPPORTED_RUNTIME_MESSAGE =
+  "[PDF-PRINT] webview.printToPDF is not available in this VS Code runtime. Requires the Electron-based desktop VS Code.";
 
 export async function renderHtmlToPdf(
   html: string,
@@ -210,9 +213,7 @@ export async function renderHtmlToPdf(
     await loaded;
     const print = panel.webview.printToPDF;
     if (typeof print !== "function") {
-      throw new Error(
-        "[PDF-PRINT] webview.printToPDF is not available in this VS Code runtime. Requires the Electron-based desktop VS Code."
-      );
+      throw new Error(UNSUPPORTED_RUNTIME_MESSAGE);
     }
     return await print({
       marginsType: 0,
@@ -281,6 +282,9 @@ async function runExport(
 ): Promise<void> {
   log.info("export-pdf invoked", { uri: sourceUri.toString() });
   try {
+    if (deps.isPrintToPdfRuntimeSupported?.() === false) {
+      throw new Error(UNSUPPORTED_RUNTIME_MESSAGE);
+    }
     const t0 = Date.now();
     const src = await readMarkdown(sourceUri, deps);
     const title = titleFromPath(sourceUri.path);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -153,6 +153,7 @@ export const activate = (context: vscode.ExtensionContext) => {
       readFile: (u) => Promise.resolve(vscode.workspace.fs.readFile(u)).then((b) => new Uint8Array(b)),
       writeFile: (u, data) => Promise.resolve(vscode.workspace.fs.writeFile(u, data)),
       uriWithPath: (base, newPath) => base.with({ path: newPath }),
+      isPrintToPdfRuntimeSupported: () => vscode.env.uiKind === vscode.UIKind.Desktop,
       createWebviewPanel: (viewType, title, showOptions, opts) =>
         vscode.window.createWebviewPanel(
           viewType,

--- a/packages/vscode/test/export-pdf.test.ts
+++ b/packages/vscode/test/export-pdf.test.ts
@@ -456,6 +456,22 @@ describe("exportPdf composer", () => {
     expect(lines.some((l) => l.includes("export-pdf failed"))).toBe(true);
   });
 
+  it("preflights unsupported runtimes before reading or composing the markdown", async () => {
+    const { deps, spies } = makeDeps({ noPrintToPdf: true });
+    const unsupportedDeps: ExportPdfDeps = {
+      ...deps,
+      isPrintToPdfRuntimeSupported: () => false,
+    };
+
+    await exportPdf(SAMPLE_URI, { theme: "light" }, unsupportedDeps);
+
+    expect(spies.readFile).not.toHaveBeenCalled();
+    expect(spies.createWebviewPanel).not.toHaveBeenCalled();
+    expect(spies.writeFile).not.toHaveBeenCalled();
+    expect(spies.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect((spies.showErrorMessage.mock.calls[0]?.[0] as string).toLowerCase()).toContain("desktop vs code");
+  });
+
   it("serialises concurrent invocations on the same URI (per-uri lock)", async () => {
     const { deps, spies } = makeDeps();
     const a = exportPdf(SAMPLE_URI, { theme: "light" }, deps);

--- a/packages/vscode/test/vscode-mock.ts
+++ b/packages/vscode/test/vscode-mock.ts
@@ -2,6 +2,7 @@
 import { vi } from "vitest";
 
 export const ViewColumn = { Beside: 2, Active: -1 } as const;
+export const UIKind = { Desktop: 1, Web: 2 } as const;
 
 const FAKE_PDF = new TextEncoder().encode("%PDF-1.7\n" + "x".repeat(2048) + "\n%%EOF\n");
 
@@ -124,5 +125,6 @@ export const Uri = {
 };
 
 export const env = {
+  uiKind: UIKind.Desktop,
   openExternal: vi.fn((_u: unknown) => Promise.resolve(true)),
 };


### PR DESCRIPTION
## TLDR

Preflight unsupported VS Code runtimes before markdown PDF export, add a regression test for the early-fail path, and ratchet `packages/web` coverage thresholds after the passing CI run.

## Details

Closes #20.

What was changed:
- Added a new `exportPdf` regression test that asserts unsupported runtimes fail before markdown is read, HTML is composed, or a PDF is written.
- Added an optional `isPrintToPdfRuntimeSupported` dependency in the VS Code PDF export path and used it to fail fast with the existing desktop-VS-Code error message.
- Wired the real runtime check in the VS Code extension through `vscode.env.uiKind === vscode.UIKind.Desktop`.
- Extended the VS Code test mock with `UIKind` and `env.uiKind` so the runtime-capability path is testable.
- Updated `coverage-thresholds.json` for `packages/web` after `make ci` passed and the repo’s ratchet step raised those thresholds.

What was added:
- No new runtime dependencies.
- One new regression test covering unsupported PDF-export runtimes.

What was changed/deleted:
- PDF export now rejects unsupported VS Code runtimes before file read/composition work starts.
- No spec/docs were changed.
- No breaking changes.

## How Do The Automated Tests Prove It Works?

- `make ci` passed end-to-end.
- `packages/vscode/test/export-pdf.test.ts` now includes `preflights unsupported runtimes before reading or composing the markdown`, which proves the command stops before `readFile`, `createWebviewPanel`, and `writeFile` on unsupported runtimes.
- The full `packages/vscode` suite passed, including `test/export-pdf.test.ts`, `test/export-pdf-physical.test.ts`, and `test/extension.test.ts`.
- The full web unit and Playwright suites passed during `make ci`, and the repo ratcheted `packages/web` coverage thresholds from the measured passing run.
