### PR TITLE
Add tuple-form union variants

### DIFF
--- a/docs/specs/language-reference.md
+++ b/docs/specs/language-reference.md
@@ -60,6 +60,20 @@ union Result<T, E> {
 }
 ```
 
+### Tuple-form variants
+
+Variants can also carry positional payloads with tuple syntax:
+
+```
+union RequestId {
+  Number(Int)
+  String(String)
+}
+```
+
+This is useful when the target language distinguishes tuple variants from
+named-field variants, such as Rust `Number(i64)` vs `Number { value: i64 }`.
+
 ## Aliases (`alias`)
 
 An alias creates a named synonym for another type.

--- a/packages/typediagram/scripts/bundle-size.mjs
+++ b/packages/typediagram/scripts/bundle-size.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const entry = resolve(here, "..", "src", "index.ts");
-const BUDGET_KB = 75;
+const BUDGET_KB = 75.5;
 
 const result = await build({
   entryPoints: [entry],

--- a/packages/typediagram/src/converters/rust.ts
+++ b/packages/typediagram/src/converters/rust.ts
@@ -1,7 +1,7 @@
 // [CONV-RUST] Rust <-> typeDiagram bidirectional converter.
 import type { Diagnostic } from "../parser/diagnostics.js";
 import { type Result, err } from "../result.js";
-import type { Model, ResolvedTypeRef } from "../model/types.js";
+import { isTupleVariantFields, type Model, type ResolvedTypeRef } from "../model/types.js";
 import { ModelBuilder, record, union, alias } from "../model/builder.js";
 import type { Converter } from "./types.js";
 import { parseTypeRef } from "./parse-typeref.js";
@@ -268,6 +268,8 @@ const toRust = (model: Model): string => {
       for (const v of d.variants) {
         if (v.fields.length === 0) {
           lines.push(`    ${v.name},`);
+        } else if (isTupleVariantFields(v.fields)) {
+          lines.push(`    ${v.name}(${v.fields.map((f) => mapTdToRs(f.type)).join(", ")}),`);
         } else {
           lines.push(`    ${v.name} { ${v.fields.map((f) => `${f.name}: ${mapTdToRs(f.type)}`).join(", ")} },`);
         }

--- a/packages/typediagram/src/layout/elk.ts
+++ b/packages/typediagram/src/layout/elk.ts
@@ -1,7 +1,13 @@
 import ELK from "elkjs/lib/elk.bundled.js";
 import type { Diagnostic } from "../parser/diagnostics.js";
 import { type Result, err, ok } from "../result.js";
-import { isTupleVariantFields, type Edge, type Model, type ResolvedDecl, type ResolvedTypeRef } from "../model/types.js";
+import {
+  isTupleVariantFields,
+  type Edge,
+  type Model,
+  type ResolvedDecl,
+  type ResolvedTypeRef,
+} from "../model/types.js";
 import { measureBlock, measureText } from "./measure.js";
 import type { EdgeRoute, LaidOutGraph, LayoutOpts, NodeBox, NodeRow } from "./types.js";
 

--- a/packages/typediagram/src/layout/elk.ts
+++ b/packages/typediagram/src/layout/elk.ts
@@ -1,7 +1,7 @@
 import ELK from "elkjs/lib/elk.bundled.js";
 import type { Diagnostic } from "../parser/diagnostics.js";
 import { type Result, err, ok } from "../result.js";
-import type { Edge, Model, ResolvedDecl, ResolvedTypeRef } from "../model/types.js";
+import { isTupleVariantFields, type Edge, type Model, type ResolvedDecl, type ResolvedTypeRef } from "../model/types.js";
 import { measureBlock, measureText } from "./measure.js";
 import type { EdgeRoute, LaidOutGraph, LayoutOpts, NodeBox, NodeRow } from "./types.js";
 
@@ -119,7 +119,11 @@ function buildPreNodes(decls: ResolvedDecl[], fontSize: number, padX: number, pa
     } else if (d.kind === "union") {
       for (const v of d.variants) {
         const variantHeader =
-          v.fields.length === 0 ? v.name : `${v.name} { ${v.fields.map((f) => rowText(f.name, f.type)).join(", ")} }`;
+          v.fields.length === 0
+            ? v.name
+            : isTupleVariantFields(v.fields)
+              ? `${v.name}(${v.fields.map((f) => printRefShort(f.type)).join(", ")})`
+              : `${v.name} { ${v.fields.map((f) => rowText(f.name, f.type)).join(", ")} }`;
         const m = measureText(variantHeader, fontSize);
         if (m.w > widest) {
           widest = m.w;

--- a/packages/typediagram/src/model/index.ts
+++ b/packages/typediagram/src/model/index.ts
@@ -15,7 +15,6 @@ export type {
 export { printSource } from "./print.js";
 export { validate } from "./validate.js";
 export {
-  isTupleVariantFields,
   PRIMITIVES,
   type Edge,
   type EdgeKind,

--- a/packages/typediagram/src/model/index.ts
+++ b/packages/typediagram/src/model/index.ts
@@ -15,6 +15,7 @@ export type {
 export { printSource } from "./print.js";
 export { validate } from "./validate.js";
 export {
+  isTupleVariantFields,
   PRIMITIVES,
   type Edge,
   type EdgeKind,

--- a/packages/typediagram/src/model/print.ts
+++ b/packages/typediagram/src/model/print.ts
@@ -1,4 +1,4 @@
-import type { Model, ResolvedDecl, ResolvedTypeRef } from "./types.js";
+import { isTupleVariantFields, type Model, type ResolvedDecl, type ResolvedTypeRef } from "./types.js";
 
 export function printSource(model: Model): string {
   const out: string[] = ["typeDiagram", ""];
@@ -20,6 +20,9 @@ function printDecl(d: ResolvedDecl): string {
       .map((v) => {
         if (v.fields.length === 0) {
           return `  ${v.name}`;
+        }
+        if (isTupleVariantFields(v.fields)) {
+          return `  ${v.name}(${v.fields.map((f) => printRef(f.type)).join(", ")})`;
         }
         const inner = v.fields.map((f) => `${f.name}: ${printRef(f.type)}`).join(", ");
         return `  ${v.name} { ${inner} }`;

--- a/packages/typediagram/src/model/types.ts
+++ b/packages/typediagram/src/model/types.ts
@@ -39,6 +39,10 @@ export interface ResolvedVariant {
   fields: ResolvedField[];
 }
 
+export function isTupleVariantFields(fields: readonly { name: string }[]): boolean {
+  return fields.every((field, index) => field.name === `_${String(index)}`);
+}
+
 export interface ResolvedTypeRef {
   /** Original name as written, e.g. `List`, `Option`, `T`, `String`, `MyType`. */
   name: string;

--- a/packages/typediagram/src/parser/lexer.ts
+++ b/packages/typediagram/src/parser/lexer.ts
@@ -8,6 +8,8 @@ export type TokenKind =
   | "Ident"
   | "LBrace"
   | "RBrace"
+  | "LParen"
+  | "RParen"
   | "LAngle"
   | "RAngle"
   | "Comma"
@@ -35,6 +37,8 @@ const KEYWORDS: Record<string, TokenKind> = {
 const SINGLE_CHAR: Record<string, TokenKind> = {
   "{": "LBrace",
   "}": "RBrace",
+  "(": "LParen",
+  ")": "RParen",
   "<": "LAngle",
   ">": "RAngle",
   ",": "Comma",

--- a/packages/typediagram/src/parser/parser.ts
+++ b/packages/typediagram/src/parser/parser.ts
@@ -251,12 +251,41 @@ class Parser {
       this.cur.next();
       fields = this.parseFieldList();
       this.expect("RBrace", "'}'");
+    } else if (this.cur.peek().kind === "LParen") {
+      this.cur.next();
+      fields = this.parseTupleVariantFieldList();
+      this.expect("RParen", "')'");
     }
     return {
       name: nameTok.value,
       fields,
       span: spanBetween(nameTok, this.cur.peek()),
     };
+  }
+
+  private parseTupleVariantFieldList(): Field[] {
+    const fields: Field[] = [];
+    for (;;) {
+      this.cur.eatNewlines();
+      if (this.cur.peek().kind === "RParen" || this.cur.peek().kind === "EOF") {
+        return fields;
+      }
+      const type = this.parseTypeRef();
+      if (type === null) {
+        return fields;
+      }
+      fields.push({
+        name: `_${String(fields.length)}`,
+        type,
+        span: type.span,
+      });
+      this.cur.eatNewlines();
+      if (this.cur.peek().kind === "Comma") {
+        this.cur.next();
+      } else {
+        return fields;
+      }
+    }
   }
 
   private parseTypeRef(): TypeRef | null {

--- a/packages/typediagram/test/converters/rust.test.ts
+++ b/packages/typediagram/test/converters/rust.test.ts
@@ -223,6 +223,21 @@ alias Lookup<K, V> = Map<K, V>
     expect(output).toContain("pub type Email = String");
     expect(output).toContain("pub type Lookup<K, V> = HashMap<K, V>");
   });
+
+  it("emits tuple enum variants from tuple-form union syntax", () => {
+    const td = `
+union RequestId {
+  Number(Int)
+  String(String)
+}
+`;
+    const model = unwrap(buildModel(unwrap(parse(td))));
+    const output = rust.toSource(model);
+
+    expect(output).toContain("pub enum RequestId");
+    expect(output).toContain("Number(i64)");
+    expect(output).toContain("String(String)");
+  });
 });
 
 describe("[CONV-RUST-RT] Rust round-trip TD -> Rust -> TD", () => {

--- a/packages/vscode/examples/sample.td
+++ b/packages/vscode/examples/sample.td
@@ -59,4 +59,9 @@ union Option<T> {
   None
 }
 
+union RequestId {
+  Number(Int)
+  String(String)
+}
+
 alias Email = String

--- a/packages/vscode/examples/spec.md
+++ b/packages/vscode/examples/spec.md
@@ -2,6 +2,17 @@
 
 A minimal single-user TODO list application. Users create lists, add tasks, mark them complete, set due dates, attach tags, and filter/search across their workspace. Data persists locally; sync is out of scope for v1.
 
+Tuple-form union variants are also supported:
+
+```typediagram
+typeDiagram
+
+union RequestId {
+  Number(Int)
+  String(String)
+}
+```
+
 ## Overview
 
 The app is organized around a **Workspace** that owns many **TodoLists**. Each list owns many **Tasks**. Tasks carry status, priority, optional due dates, optional descriptions, and tags. The UI is a three-pane layout (sidebar of lists, task table, detail pane) backed by a command/event architecture.


### PR DESCRIPTION
## TLDR

Add tuple-form union variants like `Number(Int)` to the DSL, render them as tuple variants in Rust output, and document the new syntax with examples.

<img width="700" height="107" alt="image" src="https://github.com/user-attachments/assets/99205359-e161-4180-95ea-371d748e2197" />


## Details

Closes #24.

### What Was Added

- Tuple-form union variant syntax in the parser and lexer via `(` / `)` support.
- Rust converter support for emitting tuple enum variants such as `Number(i64)`.
- A tuple-variant regression test covering `union RequestId { Number(Int) String(String) }`.
- Language-reference and VS Code sample examples for tuple-form variants.

### What Was Changed/Deleted

- Union printing and layout now preserve tuple-form variants as `Variant(T)` instead of rendering synthetic field names like `_0: T`.
- The typediagram core bundle-size budget was raised from `75 KB` to `75.5 KB` to account for the new syntax support.

### Breaking Changes

- No breaking changes.

## How Do The Automated Tests Prove It Works?

- `packages/typediagram/test/converters/rust.test.ts` now includes `emits tuple enum variants from tuple-form union syntax`, which parses tuple-form DSL and asserts Rust output contains `Number(i64)` and `String(String)`.
- `make ci` passed for the branch, including typediagram, CLI, VS Code, and web test suites, web Playwright coverage merge, and the typediagram bundle-size gate.
