### PR TITLE
fix(release): publish VS Code extension as stable by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: npm publish --workspace=packages/cli --tag ${{ steps.derive.outputs.npm_tag }} --provenance --access public
 
       - name: Package VSIX
-        run: npm run -w typediagram-vscode package -- --pre-release
+        run: npm run -w typediagram-vscode package
 
       - name: Pack npm tarballs for release assets
         run: |
@@ -88,7 +88,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "$TAG" --generate-notes --prerelease
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi
           # Collect unique assets — `typediagram-*.tgz` overlaps `typediagram-core-*.tgz`,
           # so globbing both would make `gh release upload` race against itself with


### PR DESCRIPTION
## TLDR

Publish tagged VS Code extension releases as stable by default instead of pre-release.

## Details

- Removes the `--pre-release` flag from the VSIX packaging step in `.github/workflows/release.yml`.
- Removes the `--prerelease` flag from GitHub release creation so tagged releases are no longer labeled prerelease by default.
- No runtime or package code changes.

## How Do The Automated Tests Prove It Works?

- `make ci` passed end-to-end after rerunning outside the sandbox.
- The run completed formatting, typechecking, lint, package tests, Playwright web E2E, merged coverage checks, coverage threshold enforcement, and build steps.
