### PR TITLE
feat: emit all 9 codegen languages from the CLI (F#, Dart, Protobuf, PHP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ packages/web/.typedoc-out/
 dist-test-pdfs/
 
 packages/web/test-results/
+
+.deslop-cache/
+
+.ghissues/

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 typeDiagram is a tiny, language-neutral DSL for describing **algebraic data types** — records, tagged unions, generics, aliases. From one `.td` file, you get:
 
-- **Source code** in TypeScript, Python, Rust, Go, and C# — DTOs, data classes, discriminated unions, pattern-matchable enums — generated from the same definition, always in sync.
+- **Source code** in TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, and Protobuf — DTOs, data classes, discriminated unions, pattern-matchable enums — generated from the same definition, always in sync.
 - **SVG diagrams** with automatic orthogonal layout — no dragging, no fiddling, versionable in git.
-- **Round-trip conversion** from existing TypeScript/Python/Rust/Go/C# back to the DSL, so you can retrofit an existing codebase.
+- **Round-trip conversion** from existing TypeScript/Python/Rust/Go/C#/F#/Dart/PHP/Protobuf back to the DSL, so you can retrofit an existing codebase.
 
 This is not a diagramming tool dressed up with a text input like Mermaid or PlantUML. typeDiagram is a **shared schema for your data model** — the diagram is a side effect, not the goal. The primary output is code, in as many languages as you need, kept strictly in sync by construction.
 
 ### Why this matters
 
-When your backend is Python, your mobile app is Swift/Kotlin, your web client is TypeScript, and your data pipeline is Rust, keeping DTOs aligned across five languages is a full-time job. typeDiagram inverts the problem: one definition, N outputs. Change a field, regenerate, done. Every consumer of the schema stays honest because they all build from the same source.
+When your backend is Python, your mobile app is Swift/Kotlin, your web client is TypeScript, and your data pipeline is Rust, keeping DTOs aligned across nine languages is a full-time job. typeDiagram inverts the problem: one definition, N outputs. Change a field, regenerate, done. Every consumer of the schema stays honest because they all build from the same source.
 
 ## 🚀 Try it live — no install
 

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -20,13 +20,13 @@ If `file` is omitted, reads from stdin. Output goes to stdout. Errors go to stde
 
 ## Options
 
-| Flag           | Value                                  | Description                                 |
-| -------------- | -------------------------------------- | ------------------------------------------- |
-| `--from`       | `typescript\|python\|rust\|go\|csharp` | Convert from language source to SVG         |
-| `--to`         | `typescript\|python\|rust\|go\|csharp` | Convert from typeDiagram to language source |
-| `--theme`      | `light\|dark`                          | Color theme (default: `light`)              |
-| `--font-size`  | number                                 | Font size in pixels                         |
-| `-h`, `--help` |                                        | Show help                                   |
+| Flag           | Value                                                               | Description                                 |
+| -------------- | ------------------------------------------------------------------- | ------------------------------------------- |
+| `--from`       | `typescript\|python\|rust\|go\|csharp\|fsharp\|dart\|protobuf\|php` | Convert from language source to SVG         |
+| `--to`         | `typescript\|python\|rust\|go\|csharp\|fsharp\|dart\|protobuf\|php` | Convert from typeDiagram to language source |
+| `--theme`      | `light\|dark`                                                       | Color theme (default: `light`)              |
+| `--font-size`  | number                                                              | Font size in pixels                         |
+| `-h`, `--help` |                                                                     | Show help                                   |
 
 `--from` and `--to` are mutually exclusive.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # typediagram
 
-**CLI for [typeDiagram](https://typediagram.dev).** Render the typeDiagram DSL to SVG, or convert between the DSL and TypeScript, Python, Rust, Go, and C#.
+**CLI for [typeDiagram](https://typediagram.dev).** Render the typeDiagram DSL to SVG, or convert between the DSL and TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, and Protobuf.
 
 **Live demo:** [typediagram.dev](https://typediagram.dev)
 
@@ -28,14 +28,14 @@ cat schema.td | typediagram > diagram.svg
 
 ## Options
 
-| Flag            | Values                                         | Default |
-| --------------- | ---------------------------------------------- | ------- |
-| `--from <lang>` | `typescript`, `python`, `rust`, `go`, `csharp` | —       |
-| `--to <lang>`   | `typescript`, `python`, `rust`, `go`, `csharp` | —       |
-| `--emit <fmt>`  | `svg`, `td`, `td+svg` (for `--from`)           | `svg`   |
-| `--theme`       | `light`, `dark`                                | `light` |
-| `--font-size N` | font size in px                                | —       |
-| `-h`, `--help`  | show help                                      |         |
+| Flag            | Values                                                                              | Default |
+| --------------- | ----------------------------------------------------------------------------------- | ------- |
+| `--from <lang>` | `typescript`, `python`, `rust`, `go`, `csharp`, `fsharp`, `dart`, `protobuf`, `php` | —       |
+| `--to <lang>`   | `typescript`, `python`, `rust`, `go`, `csharp`, `fsharp`, `dart`, `protobuf`, `php` | —       |
+| `--emit <fmt>`  | `svg`, `td`, `td+svg` (for `--from`)                                                | `svg`   |
+| `--theme`       | `light`, `dark`                                                                     | `light` |
+| `--font-size N` | font size in px                                                                     | —       |
+| `-h`, `--help`  | show help                                                                           |         |
 
 If no file is given, stdin is read. Output goes to stdout; errors go to stderr.
 

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,10 +1,15 @@
 // [CLI-ARGS] Parse argv for typediagram CLI.
+import { converters } from "typediagram-core";
 import type { Result } from "./result.js";
 import { err, ok } from "./result.js";
 
 export type Theme = "light" | "dark";
-export type Lang = "typescript" | "python" | "rust" | "go" | "csharp";
+// [CLI-LANG] The supported language set is the framework registry — never hardcoded here,
+// so the CLI can never advertise a language the framework cannot emit (or omit one it can).
+export type Lang = converters.Language;
 export type Emit = "svg" | "td" | "td+svg";
+
+const LANG_LIST = converters.LANGUAGES.join("|");
 
 export interface CliArgs {
   readonly file: string | null;
@@ -21,7 +26,7 @@ export interface ArgError {
 }
 
 const THEMES: ReadonlySet<Theme> = new Set<Theme>(["light", "dark"]);
-const LANGS: ReadonlySet<Lang> = new Set<Lang>(["typescript", "python", "rust", "go", "csharp"]);
+const LANGS: ReadonlySet<Lang> = new Set<Lang>(converters.LANGUAGES);
 const EMITS: ReadonlySet<Emit> = new Set<Emit>(["svg", "td", "td+svg"]);
 
 const isTheme = (v: string): v is Theme => THEMES.has(v as Theme);
@@ -114,11 +119,11 @@ const applyLang = (
   key: "from" | "to"
 ): Result<true, ArgError> =>
   v === null
-    ? err({ message: `--${key} expects typescript|python|rust|go|csharp` })
+    ? err({ message: `--${key} expects ${LANG_LIST}` })
     : isLang(v)
       ? ((s[key] = v), ok(true as const))
       : err({
-          message: `--${key} expects typescript|python|rust|go|csharp, got ${v}`,
+          message: `--${key} expects ${LANG_LIST}, got ${v}`,
         });
 
 const applyEmit = (v: string | null, s: { emit: Emit }): Result<true, ArgError> =>
@@ -134,12 +139,14 @@ Usage:
   typediagram [options] [file]
 
 Options:
-  --from typescript|python|rust|go|csharp   Convert from language source to SVG
-  --to   typescript|python|rust|go|csharp   Convert from typeDiagram to language source
-  --emit svg|td|td+svg              Output format for --from (default: svg)
-  --theme light|dark                 Color theme (default: light)
-  --font-size N                      Font size in px
-  -h, --help                         Show this help
+  --from LANG          Convert from language source to SVG
+  --to   LANG          Convert from typeDiagram to language source
+  --emit svg|td|td+svg Output format for --from (default: svg)
+  --theme light|dark   Color theme (default: light)
+  --font-size N        Font size in px
+  -h, --help           Show this help
+
+LANG is one of: ${LANG_LIST}
 
 If file is omitted, reads from stdin.
 SVG (or language source with --to) is written to stdout.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,16 +8,8 @@ import {
   type AllOpts,
   type Diagnostic,
 } from "typediagram-core";
-import { HELP_TEXT, parseArgs, type CliArgs, type Lang } from "./args.js";
+import { HELP_TEXT, parseArgs, type CliArgs } from "./args.js";
 import { readSource } from "./io.js";
-
-const CONVERTER_MAP: Record<Lang, typeof converters.typescript> = {
-  typescript: converters.typescript,
-  python: converters.python,
-  rust: converters.rust,
-  go: converters.go,
-  csharp: converters.csharp,
-};
 
 export const main = async (
   argv: readonly string[],
@@ -50,7 +42,7 @@ const fromLangFlow = async (
   if (args.from === null) {
     return (stderr.write("missing --from\n"), 1);
   }
-  const conv = CONVERTER_MAP[args.from];
+  const conv = converters.byLanguage[args.from];
   const modelResult = conv.fromSource(srcRes.value);
   if (!modelResult.ok) {
     return (writeDiagnostics(modelResult.error, stderr), 1);
@@ -101,7 +93,7 @@ const toLangFlow = async (
   if (args.to === null) {
     return (stderr.write("missing --to\n"), 1);
   }
-  const conv = CONVERTER_MAP[args.to];
+  const conv = converters.byLanguage[args.to];
   stdout.write(conv.toSource(model.value));
   return 0;
 };

--- a/packages/cli/test/multi-language-pipeline.e2e.test.ts
+++ b/packages/cli/test/multi-language-pipeline.e2e.test.ts
@@ -100,6 +100,10 @@ describe("[CLI-PIPELINE-DOCS] multi-language pipeline doc examples", () => {
     { lang: "python", expect: "class User" },
     { lang: "go", expect: "type User struct" },
     { lang: "csharp", expect: "record User" },
+    { lang: "fsharp", expect: "type User = {" },
+    { lang: "dart", expect: "class User" },
+    { lang: "protobuf", expect: "message User" },
+    { lang: "php", expect: "final readonly class User" },
   ])("--to $lang emits $lang source for a simple record", async ({ lang, expect: needle }) => {
     const root = await mkdtemp(join(tmpdir(), "td-pipeline-"));
     const schemaPath = join(root, "s.td");

--- a/packages/typediagram/README.md
+++ b/packages/typediagram/README.md
@@ -1,6 +1,6 @@
 # typediagram-core
 
-**Type-safe diagrams and source code from one schema.** Parse a tiny DSL (records, tagged unions, aliases) into a model, then generate SVG diagrams and round-trip types for TypeScript, Python, Rust, Go, C#, and F#.
+**Type-safe diagrams and source code from one schema.** Parse a tiny DSL (records, tagged unions, aliases) into a model, then generate SVG diagrams and round-trip types for TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, and Protobuf.
 
 **Live demo:** [typediagram.dev](https://typediagram.dev)
 

--- a/packages/typediagram/src/converters/index.ts
+++ b/packages/typediagram/src/converters/index.ts
@@ -1,12 +1,33 @@
 // [CONV] Barrel export for all language converters.
-export { typescript } from "./typescript.js";
-export { python } from "./python.js";
-export { rust } from "./rust.js";
-export { go } from "./go.js";
-export { csharp } from "./csharp.js";
-export { fsharp } from "./fsharp.js";
-export { dart } from "./dart.js";
-export { protobuf } from "./protobuf.js";
-export { php } from "./php.js";
+import { typescript } from "./typescript.js";
+import { python } from "./python.js";
+import { rust } from "./rust.js";
+import { go } from "./go.js";
+import { csharp } from "./csharp.js";
+import { fsharp } from "./fsharp.js";
+import { dart } from "./dart.js";
+import { protobuf } from "./protobuf.js";
+import { php } from "./php.js";
+import type { Converter, Language } from "./types.js";
+
+export { typescript, python, rust, go, csharp, fsharp, dart, protobuf, php };
 export { parseTypeRef, printTypeRef } from "./parse-typeref.js";
 export type { Converter, Language } from "./types.js";
+
+// [CONV-REGISTRY] Canonical language→converter map. Typing it Record<Language, Converter>
+// makes a missing entry a COMPILE error, so the advertised language set can never drift
+// from what actually emits. Single source of truth for CLI/web/vscode language lists.
+export const byLanguage: Record<Language, Converter> = {
+  typescript,
+  python,
+  rust,
+  go,
+  csharp,
+  fsharp,
+  dart,
+  protobuf,
+  php,
+};
+
+// Keys of a Record<Language, …> are exactly the Language members, so this cast is sound.
+export const LANGUAGES = Object.keys(byLanguage) as readonly Language[];

--- a/packages/web/eleventy/converter.njk
+++ b/packages/web/eleventy/converter.njk
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
-title: Convert TypeScript, Python, Rust, Go & C# to Diagrams — typeDiagram
-description: Paste TypeScript, Rust, Python, Go, or C# code and instantly convert it to typeDiagram DSL plus an SVG diagram. Free online converter, no signup.
+title: Convert TypeScript, Python, Rust, Go, C#, F#, Dart, PHP & Protobuf to Diagrams — typeDiagram
+description: Paste TypeScript, Rust, Python, Go, C#, F#, Dart, PHP, or Protobuf code and instantly convert it to typeDiagram DSL plus an SVG diagram. Free online converter, no signup.
 permalink: /converter.html
 scriptSrc: /src/converter-main.ts
 bodyClass: converter-body
@@ -17,7 +17,7 @@ structuredData:
   "@type": "WebApplication"
   name: "typeDiagram Converter"
   url: "https://typediagram.dev/converter.html"
-  description: "Convert TypeScript, Python, Rust, Go, or C# type definitions into typeDiagram DSL and an SVG diagram."
+  description: "Convert TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, or Protobuf type definitions into typeDiagram DSL and an SVG diagram."
   applicationCategory: "DeveloperApplication"
   operatingSystem: "Any (browser)"
   offers:
@@ -29,7 +29,7 @@ structuredData:
 <main class="converter-page">
   <header class="conv-header">
     <h1 class="conv-title"><span class="hero-accent">Convert</span> any language to a type diagram.</h1>
-    <p class="conv-sub">Paste TypeScript, Rust, Python, Go, or C# — get typeDiagram source and SVG instantly.</p>
+    <p class="conv-sub">Paste TypeScript, Rust, Python, Go, C#, F#, Dart, PHP, or Protobuf — get typeDiagram source and SVG instantly.</p>
   </header>
   <div id="converter-mount" class="converter-mount"></div>
 </main>


### PR DESCRIPTION
## Summary

The framework ships bidirectional converters for **9** languages, but the CLI only reached **5** (`typescript|python|rust|go|csharp`). `--to fsharp|dart|protobuf|php` were impossible despite the converters existing, tested, in `typediagram-core`. This wires the CLI to the full set and removes the duplicated language lists that caused the drift.

## What changed

- **`typediagram-core`**: canonical `byLanguage: Record<Language, Converter>` registry + `LANGUAGES` array. Typing it `Record<Language, …>` makes a missing converter a **compile error**, so the advertised set can never drift from what actually emits. *(already on branch)*
- **CLI**: drop the hardcoded 5-entry `CONVERTER_MAP`; derive `Lang`, validation, help text and dispatch from `converters.byLanguage` / `converters.LANGUAGES`. This also makes the branch typecheck again — `args.ts` had widened `Lang` to all 9, leaving the old 5-key `Record<Lang>` map incomplete.
- **Tests**: extend the multi-language e2e pipeline to assert `--to` for all 9 languages.
- **Docs/SEO**: correct README (root + cli + core), the CLI spec, and converter page copy that still advertised only 5.

## Verification

Full `make ci` green locally: fmt ✓ · lint ✓ (0 errors) · test+coverage ✓ (lines 98.62%, all thresholds met, ratchet clean) · build ✓ · bundle-size ✓.

Downstream `Napper` independently verified `--to fsharp` against this branch and is waiting on the published release to drop its hand-synced `Types.fs`.