### PR TITLE
OIDC Marketplace publishing (no PAT, no silent skip) + selective CI + scalar docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,39 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+          # Full history so the change-scope step can diff against the PR base.
+          fetch-depth: 0
+
+      # [CI-SCOPE-FILTER] Website/docs-only PRs skip the full framework test
+      # matrix, bundle-size, Playwright e2e, and Shipwright gates — they run a
+      # lightweight build + lint + web-unit check instead. The single `CI` job
+      # always runs and reports, so it stays valid as a required status check
+      # (path filters that skip the job would leave it pending forever).
+      # "Web scope" = every changed path is under packages/web/, docs/, or is a
+      # *.md file; anything else (framework/cli/vscode src, Makefile, configs,
+      # workflows) forces the full pipeline.
+      - name: Detect change scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          ALLOW='(^packages/web/)|(^docs/)|(\.md$)'
+          CHANGED="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          echo "Changed files:"
+          echo "$CHANGED"
+          # Count paths OUTSIDE the website/docs allowlist. `grep -c` exits 1 on a
+          # zero count, so `|| true` keeps it from tripping `set -e`/pipefail.
+          # (Count is used rather than `grep -q`, whose -q/-v combo is unreliable
+          # on BSD grep.)
+          NON_WEB="$(printf '%s\n' "$CHANGED" | grep -cvE "$ALLOW" || true)"
+          if [ -z "$CHANGED" ] || [ "$NON_WEB" -gt 0 ]; then
+            echo "scope=full" >> "$GITHUB_OUTPUT"
+            echo "==> Scope: FULL ($NON_WEB non-website path(s) changed)"
+          else
+            echo "scope=web" >> "$GITHUB_OUTPUT"
+            echo "==> Scope: WEB (website/docs-only changes)"
+          fi
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -37,21 +70,39 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # [SWR-SEC-VULN-GATE] fail at high for production dependencies.
+      # [SWR-SEC-VULN-GATE] fail at high for production dependencies. Cheap;
+      # runs in both scopes.
       - name: Dependency vulnerability gate
         run: npm audit --omit=dev --audit-level=high
 
+      # ───────────── Website/docs-only scope (lightweight) ─────────────
+      # Validates that the site compiles and the web package is clean without
+      # paying for the full cross-workspace test/build/gate pipeline.
+      - name: Website checks (format, lint, typecheck, web tests, site build)
+        if: steps.scope.outputs.scope == 'web'
+        run: |
+          npm run fmt:check
+          npm run lint
+          npm run -w typediagram-core build
+          npm run -w @typediagram/web typecheck
+          npm run -w @typediagram/web test:unit
+          npm run -w @typediagram/web build
+
+      # ───────────────────────── Full scope ───────────────────────────
       # Playwright needs chromium for the packages/web E2E tests. --with-deps
       # ensures required OS libraries are present on ubuntu-latest.
       - name: Install Playwright browsers
+        if: steps.scope.outputs.scope == 'full'
         run: npx --workspace=@typediagram/web playwright install chromium --with-deps
 
       # Single `make ci` step runs the full pipeline (fmt-check -> lint -> test -> build -> bundle-size).
       - name: CI (make ci)
+        if: steps.scope.outputs.scope == 'full'
         run: make ci
 
       # [SWR-GATE-CI] [SWR-GATE-VERIFY-BINARIES] manifest + CLI version contract.
       - name: Shipwright acceptance gates
+        if: steps.scope.outputs.scope == 'full'
         run: |
           npx --yes @nimblesite/shipwright-validate-manifest@0.9.0 --schema schemas/shipwright.schema.json shipwright.json
           npm run -w typediagram build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,14 +173,70 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # [SWR-VSIX-PUBLISH] Marketplace publish — skips cleanly until the VSCE_PAT
-      # secret is configured in the NPM Deployment environment.
-      - name: Publish VSIX to VS Code Marketplace
+      # Hand the packaged VSIX to publish-marketplace. That job runs in the
+      # `release` environment so its OIDC subject matches the Entra trust; it
+      # can't share this job's environment, so the VSIX crosses as an artifact.
+      - name: Upload VSIX artifact for Marketplace publish
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vsix
+          path: typediagram-*.vsix
+          if-no-files-found: error
+          retention-days: 1
+
+  # [SWR-VSIX-PUBLISH] Marketplace publish via Microsoft Entra OIDC — NO stored PAT.
+  # Runs in the `release` environment so the GitHub OIDC subject is
+  # `repo:Nimblesite/typeDiagram:environment:release`, which the shared Entra app's
+  # wildcard federated credential (`repo:Nimblesite/*:environment:release`) trusts.
+  # Runbook: Nimblesite/NimblesiteDeployment docs/vscode-marketplace-oidc.md (Part D).
+  # There is intentionally NO silent skip — a missing identity or a publish failure
+  # fails this job and turns the release red.
+  publish-marketplace:
+    name: Publish VSIX to VS Code Marketplace
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # request the GitHub OIDC token for azure/login
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: vsix
+          path: vsix
+
+      # Exchange the GitHub OIDC token for an Entra session — no client secret, no PAT.
+      # The publisher app holds no Azure subscription role (its only authorization is
+      # Marketplace publisher membership) → allow-no-subscriptions.
+      - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Publish VSIX (Entra OIDC, no PAT)
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "VSCE_PAT not configured — skipping Marketplace publish"
-            exit 0
+          set -euo pipefail
+          VSIX="$(ls vsix/typediagram-*.vsix 2>/dev/null | head -1)"
+          if [ -z "$VSIX" ] || [ ! -f "$VSIX" ]; then
+            echo "::error::No VSIX artifact found to publish" >&2
+            exit 1
           fi
-          npx --yes @vscode/vsce@3.9.2 publish --packagePath "$(ls typediagram-*.vsix | head -1)" --pat "$VSCE_PAT"
+          # Pre-release only for pre-release tags (v1.2.3-beta); a clean vX.Y.Z is stable.
+          flag=""
+          [[ "$GITHUB_REF_NAME" == *-* ]] && flag="--pre-release"
+          # Mint a Marketplace-scoped token from the OIDC session. 499b84ac-… is Azure
+          # DevOps' immutable first-party app id vsce authenticates against. We mint and
+          # pass it ourselves rather than `vsce publish --azure-credential` (buggy:
+          # microsoft/vscode-vsce#1023).
+          VSCE_PAT="$(az account get-access-token \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+            --query accessToken -o tsv)"
+          echo "::add-mask::$VSCE_PAT"
+          export VSCE_PAT
+          # Pinned vsce (a floating npx would run latest inside a token-holding job).
+          # --skip-duplicate keeps re-runs idempotent; any real failure fails loudly.
+          npx --yes @vscode/vsce@3.9.2 publish ${flag} --skip-duplicate --packagePath "$VSIX"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ code --install-extension Nimblesite.typediagram
 typeDiagram
 
 type User {
-  id:    UUID
+  id:    Uuid
   name:  String
   email: Option<Email>
 }

--- a/docs/plans/marketplace-oidc-and-0.11.0.md
+++ b/docs/plans/marketplace-oidc-and-0.11.0.md
@@ -1,0 +1,89 @@
+# Plan — Fix Marketplace publishing (OIDC) + ship v0.11.0
+
+Status: in progress · Owner: release automation · Date: 2026-06-12
+
+## Problem
+
+The VS Code Marketplace is stuck at **0.8.0**. Releases 0.9.0 and 0.10.0 published to
+npm + GitHub Releases but **never reached the Marketplace**: the release workflow's
+publish step is gated on a `VSCE_PAT` secret that is not configured, and on a missing
+PAT it prints a message and `exit 0` — so the step goes green and the miss is silent.
+
+Two faults:
+
+1. **Silent skip.** A missing publish credential must fail loudly, not pass.
+2. **Wrong auth model.** `VSCE_PAT` (a long-lived stored token) is disallowed. Publishing
+   must use **OIDC / Microsoft Entra workload identity federation** — matching
+   `shipwright.json` (`oidcPublish: true`) and the Nimblesite runbook.
+
+## Authoritative references
+
+- Nimblesite/NimblesiteDeployment `docs/vscode-marketplace-oidc.md` (Part D job shape),
+  `docs/onboarding-a-new-vsix.md`, `docs/azure-inventory.md`.
+- Nimblesite/Shipwright `docs/specs/vsix-platform-bundling.md` (`SWR-VSIX-PUBLISH`,
+  `SWR-VSIX-FAT`), `docs/specs/supply-chain-security.md`, `docs/specs/acceptance-gates.md`.
+
+Key facts from the runbooks:
+
+- One shared Entra app `Nimblesite-VSCode-Marketplace` publishes **all** Nimblesite
+  extensions; authorization is at the **publisher** level (already a Contributor member
+  via Identity GUID `767f2589-2687-6e24-bd6a-2b569a9e3308`). **No new Azure objects.**
+- A **wildcard flexible federated credential** trusts
+  `repo:Nimblesite/*:environment:release`. The publish job MUST run in a GitHub
+  `environment: release` so the OIDC subject matches.
+- `vsce publish --azure-credential` is buggy (vscode-vsce#1023). The working pattern
+  mints a Marketplace-scoped token from the OIDC session and passes it as `VSCE_PAT`:
+  `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798`.
+- typeDiagram's extension is **pure-JS → single fat VSIX** (`SWR-VSIX-FAT`); no
+  `--target` platform matrix.
+- Non-secret IDs: `AZURE_CLIENT_ID = beacf14a-c783-4bab-80a6-dd4936cb1da3`,
+  `AZURE_TENANT_ID = 0a282151-85df-4a81-b083-52221a26d8e7`.
+
+## Steps
+
+### A. GitHub repo config (Part B onboarding) — `gh`, no Azure objects
+
+- [x] Create `release` environment on `Nimblesite/typeDiagram`.
+- [x] Set `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` as `release`-environment secrets
+      (non-sensitive directory identifiers, from inventory).
+- [x] Confirm publisher membership already covers `nimblesite.*` (shared app) — the
+      extension's publisher is `nimblesite`, covered by the shared Contributor member.
+- [x] github-pages env: deploy-pages runs on `workflow_run` from `main`, not a tag, so
+      the Part E tag-policy gotcha does not apply.
+
+### B. Rewrite `release.yml` marketplace publish
+
+- [x] In the `release` job, upload the packaged VSIX as a workflow artifact for the
+      publish job to consume.
+- [x] Remove the `VSCE_PAT` env + silent-skip step entirely.
+- [x] Add a separate `publish-marketplace` job: `needs: release`,
+      `environment: release`, `permissions: { contents: read, id-token: write }`.
+      Steps: download VSIX artifact → `azure/login` (OIDC, `allow-no-subscriptions`) →
+      mint token via `az account get-access-token --resource 499b84ac-…` →
+      `vsce publish` (pinned `@vscode/vsce@3.9.2`), `--pre-release` only for `-`-suffixed
+      tags, `--skip-duplicate` for idempotent re-runs, `set -euo pipefail`, mask token.
+      **No `exit 0` skip — any real failure fails the job (red release).**
+- [x] Pin `azure/login` (`a457da9…`, v2.3.0) and `download-artifact` (`d3f86a1…`, v4.3.0)
+      by 40-char commit SHA (`SWR-SEC-ACTION-PINNING`).
+
+### C. Finish the docs/website content for the scalars + unknown-type feature
+
+- [x] `language-reference.md`, `converters.md` (scalars + codegen strictness).
+- [x] `cli.md` (exit-1 on unknown types).
+- [x] `getting-started.md`, root `README.md` (UUID → Uuid).
+- [x] New blog post announcing the release.
+- [x] CI made path-selective so website/docs-only PRs skip the full pipeline.
+
+### D. Ship v0.11.0
+
+- [ ] Commit all of the above on `fixes`; open PR → `main`; CI green; merge.
+- [ ] Tag `v0.11.0` from `main` → release workflow stamps 0.11.0, publishes npm + GitHub
+      Release, and now the OIDC `publish-marketplace` job pushes the VSIX.
+- [ ] Monitor both workflows; confirm Marketplace shows **0.11.0** (full release, not
+      pre-release).
+- [ ] Record typeDiagram in the NimblesiteDeployment onboarded-repos table (follow-up).
+
+## Guard rails
+
+- No stored PAT anywhere. No silent skips. Actions SHA-pinned. CI-only publish.
+- `v0.11.0` is a clean (non-prerelease) tag → stable Marketplace release.

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -88,10 +88,10 @@ typediagram --to csharp schema.td > Models.cs
 
 ## Exit codes
 
-| Code | Meaning                                         |
-| ---- | ----------------------------------------------- |
-| 0    | Success                                         |
-| 1    | Parse error, render error, or invalid arguments |
+| Code | Meaning                                                        |
+| ---- | -------------------------------------------------------------- |
+| 0    | Success                                                        |
+| 1    | Parse error, render error, unknown type in `--to`, or bad args |
 
 Parse errors include `line:col` diagnostics on stderr:
 
@@ -99,6 +99,19 @@ Parse errors include `line:col` diagnostics on stderr:
   3:12  error   expected '{', got Ident "User"
   7:1   error   unexpected token EOF
 ```
+
+### Unknown types fail `--to`
+
+Code generation is strict: every referenced type must be a primitive, a generic built-in (`List`, `Map`, `Option`, `Any`), a declared type, or a generic parameter. An unknown name (a typo, or an unsupported type) exits **1** with a diagnostic instead of emitting source that won't compile:
+
+```sh
+$ printf 'type Probe {\n  a: Timestamp\n}\n' | typediagram --to python
+  0:0  error   unknown type 'Timestamp': not a primitive, builtin, or declared type — declare it or use a builtin scalar
+$ echo $?
+1
+```
+
+Use the built-in semantic scalars `DateTime`, `Uuid`, and `Decimal` for timestamps, ids, and money — they map to each language's native type. Rendering a diagram (without `--to`) still treats unknown names as opaque external references.
 
 ## Makefile shortcuts
 

--- a/docs/specs/converters.md
+++ b/docs/specs/converters.md
@@ -12,6 +12,20 @@ Python source      ←──  Model  ←──  typeDiagram source
 
 Converters target the **Model** layer (Layer 2 of the framework). They don't round-trip through DSL text — they work directly with the resolved type graph.
 
+## Semantic scalars
+
+Beyond `Bool`/`Int`/`Float`/`String`/`Bytes`/`Unit`, three semantic scalars — `DateTime`, `Uuid`, and `Decimal` — map to the **native** date / UUID / decimal type of each language in both directions. A timestamp stays a `datetime.datetime` / `DateTimeOffset` / `time.Time`, an id stays a `uuid.UUID` / `Guid` / `uuid::Uuid` — never a bare string. The emitters also pull in the required imports automatically (Python `import datetime`, Go `import "time"`, Protobuf `import "google/protobuf/timestamp.proto"`).
+
+| typeDiagram | Python              | C# / F#          | TypeScript     | Rust                            | Go          | Dart       | Protobuf                    | PHP                  |
+| ----------- | ------------------- | ---------------- | -------------- | ------------------------------- | ----------- | ---------- | --------------------------- | -------------------- |
+| `DateTime`  | `datetime.datetime` | `DateTimeOffset` | `string` (ISO) | `chrono::DateTime<chrono::Utc>` | `time.Time` | `DateTime` | `google.protobuf.Timestamp` | `\DateTimeImmutable` |
+| `Uuid`      | `uuid.UUID`         | `Guid`           | `string`       | `uuid::Uuid`                    | `string`    | `String`   | `string`                    | `string`             |
+| `Decimal`   | `decimal.Decimal`   | `decimal`        | `string`       | `rust_decimal::Decimal`         | `string`    | `String`   | `string`                    | `string`             |
+
+## Unknown types fail generation
+
+When you emit to a language (`--to`), every referenced type must resolve to a primitive, a generic built-in (`List`, `Map`, `Option`, `Any`), a declared type, or a generic parameter. A name that resolves to none of these — a typo or an unsupported type like `Timestamp` or `Instant` — is rejected with a non-zero exit code and a diagnostic, instead of being passed through verbatim into source that won't compile. (Rendering a diagram still treats unknown names as opaque external references — only code generation is strict.)
+
 ## TypeScript
 
 ### What maps

--- a/docs/specs/getting-started.md
+++ b/docs/specs/getting-started.md
@@ -41,7 +41,7 @@ Create a file called `schema.td`:
 typeDiagram
 
 type User {
-  id:    UUID
+  id:    Uuid
   name:  String
   email: Option<Email>
 }

--- a/docs/specs/language-reference.md
+++ b/docs/specs/language-reference.md
@@ -92,7 +92,7 @@ An alias creates a named synonym for another type.
 
 ```
 alias Email = String
-alias UserId = UUID
+alias UserId = Uuid
 alias Callback = Option<String>
 ```
 
@@ -109,15 +109,32 @@ These primitive types are always available (no declaration needed):
 | `Bytes`  | Binary data     |
 | `Unit`   | No value (void) |
 
+### Semantic scalars
+
+Three semantic scalars are also built in. They render like any other primitive, but code generation maps each one to the **native** date / UUID / decimal type of the target language — so a timestamp or an id keeps its real type instead of degrading to a plain string.
+
+| typeDiagram | Python              | C# / F#          | TypeScript     | Rust                            | Go          | Dart       | Protobuf                    | PHP                  |
+| ----------- | ------------------- | ---------------- | -------------- | ------------------------------- | ----------- | ---------- | --------------------------- | -------------------- |
+| `DateTime`  | `datetime.datetime` | `DateTimeOffset` | `string` (ISO) | `chrono::DateTime<chrono::Utc>` | `time.Time` | `DateTime` | `google.protobuf.Timestamp` | `\DateTimeImmutable` |
+| `Uuid`      | `uuid.UUID`         | `Guid`           | `string`       | `uuid::Uuid`                    | `string`    | `String`   | `string`                    | `string`             |
+| `Decimal`   | `decimal.Decimal`   | `decimal`        | `string`       | `rust_decimal::Decimal`         | `string`    | `String`   | `string`                    | `string`             |
+
+A declaration that reuses a built-in name shadows it: `alias Uuid = String` makes `Uuid` mean `String` again. Declared names always win over built-ins, so existing schemas never break.
+
 ## Container types
 
-These are conventionally used but not built-in — they render as external references:
+These generic built-ins are understood by every converter. They render as external references unless declared in the diagram:
 
 | Type        | Description                                              |
 | ----------- | -------------------------------------------------------- |
 | `List<T>`   | Ordered collection                                       |
 | `Map<K, V>` | Key-value mapping                                        |
 | `Option<T>` | Optional value (declare as a union to get diagram edges) |
+| `Any`       | Opaque / dynamic value                                   |
+
+## Code generation and unknown types
+
+Rendering a diagram is lenient: any name you reference that isn't a primitive or a declared type is treated as an opaque **external** reference and drawn as inline text. Code generation (`--to <language>`) is stricter. Every referenced name must resolve to a primitive, a generic built-in (`List`, `Map`, `Option`, `Any`), a declared type, or a generic parameter. An unknown name — a typo, or an unsupported type like `Timestamp` or `Instant` — fails generation with a non-zero exit code instead of silently emitting a symbol that won't compile in the target language.
 
 ## Comments
 
@@ -148,7 +165,7 @@ Edges are drawn automatically when a field or variant references another type de
 - **Variant payload → Type**: solid arrow from the variant row
 - **Generic argument → Type**: thin dashed arrow, labeled with the parameter
 
-References to undeclared types (like `UUID`, `String`) render as inline text only — no dangling edges.
+References to undeclared types (like `CountryCode` or any name not declared in the file) render as inline text only — no dangling edges.
 
 ## Grammar (formal)
 

--- a/packages/web/eleventy/blog/datetime-uuid-decimal-scalars.md
+++ b/packages/web/eleventy/blog/datetime-uuid-decimal-scalars.md
@@ -1,0 +1,92 @@
+---
+title: "typeDiagram 0.11: Native DateTime, Uuid & Decimal — and Codegen That Refuses to Lie"
+date: 2026-06-12
+author: "The typeDiagram team"
+description: "typeDiagram 0.11 adds native DateTime, Uuid, and Decimal scalars that generate real datetime / UUID / decimal types in TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, and Protobuf — plus strict code generation that fails on unknown type names instead of emitting code that won't compile. The fix for schema drift on timestamps and ids."
+permalink: "/blog/datetime-uuid-decimal-scalars/index.html"
+---
+
+If you generate types from one schema across several languages, the failure you fear most is **schema drift** — the moment your generated code and your hand-written code quietly disagree. Drift detection is one of the defining backend concerns of 2026: API teams are building whole [spec-conformance pipelines](https://pactflow.io/blog/schemas-can-be-contracts/) just to catch the day a service's real responses stop matching its documented schema.
+
+typeDiagram exists to remove that whole class of bug — one `.td` file generates TypeScript, Python, Rust, Go, C#, F#, Dart, PHP, and Protobuf types that are in sync **by construction**. But until now it had a gap exactly where drift hurts most: **timestamps and ids**.
+
+**typeDiagram 0.11 closes that gap.** Two changes, both aimed at making the generated code the honest single source of truth.
+
+## 1. Native semantic scalars: `DateTime`, `Uuid`, `Decimal`
+
+Before 0.11, the only primitives were `Bool`, `Int`, `Float`, `String`, `Bytes`, and `Unit`. A `created_at` timestamp or a `conversation_id` could only be modelled as `String`. So the generated DTOs typed them as `str` / `string` — and every consumer that actually wanted a `datetime` or a `UUID` had to hand-patch the output. That hand-patched copy is precisely what drifts.
+
+0.11 makes `DateTime`, `Uuid`, and `Decimal` built-in scalars. They render like any other primitive, but code generation maps each one to the **native** type of the target language:
+
+| typeDiagram | Python              | C# / F#          | TypeScript     | Rust                            | Go          | Dart       | Protobuf                    | PHP                  |
+| ----------- | ------------------- | ---------------- | -------------- | ------------------------------- | ----------- | ---------- | --------------------------- | -------------------- |
+| `DateTime`  | `datetime.datetime` | `DateTimeOffset` | `string` (ISO) | `chrono::DateTime<chrono::Utc>` | `time.Time` | `DateTime` | `google.protobuf.Timestamp` | `\DateTimeImmutable` |
+| `Uuid`      | `uuid.UUID`         | `Guid`           | `string`       | `uuid::Uuid`                    | `string`    | `String`   | `string`                    | `string`             |
+| `Decimal`   | `decimal.Decimal`   | `decimal`        | `string`       | `rust_decimal::Decimal`         | `string`    | `String`   | `string`                    | `string`             |
+
+The emitters also pull in the imports each type needs — `import datetime`, `import "time"`, `import "google/protobuf/timestamp.proto"` — so the output compiles as-is.
+
+So this schema:
+
+```
+type AuditEvent {
+  id: Uuid
+  createdAt: DateTime
+  amount: Decimal
+}
+```
+
+now generates this Python, with the real types:
+
+```python
+from __future__ import annotations
+import datetime
+import uuid
+import decimal
+from dataclasses import dataclass
+
+@dataclass
+class AuditEvent:
+    id: uuid.UUID
+    createdAt: datetime.datetime
+    amount: decimal.Decimal
+```
+
+The conversion is bidirectional: point `--from` at existing code and a `datetime.datetime`, `Guid`, or `chrono::DateTime` maps straight back to the scalar.
+
+Already using a type called `Uuid`? Nothing breaks. A declaration with the same name as a built-in **shadows** it — `alias Uuid = String` still means `String`. Declared names always win.
+
+## 2. Unknown type names now fail generation — loudly
+
+The more dangerous bug was silent. Given a typo or an unsupported type:
+
+```
+type Probe {
+  a: Timestamp   # not a real typeDiagram type
+}
+```
+
+the old CLI emitted `a: Timestamp` into your Python with **exit code 0**. The reference is to a symbol that doesn't exist — a `NameError` at import time — and nothing warned you. A bad type name was indistinguishable from a good one until the consuming project failed to build.
+
+In 0.11, code generation is strict. Every referenced name must resolve to a primitive, a generic built-in (`List`, `Map`, `Option`, `Any`), a declared type, or a generic parameter. Anything else fails the generation:
+
+```sh
+$ typediagram --to python schema.td
+  0:0  error   unknown type 'Timestamp': not a primitive, builtin, or declared type — declare it or use a builtin scalar
+$ echo $?
+1
+```
+
+The error stops at the generator, where you can fix it, instead of leaking into a downstream build. Rendering a diagram is unchanged — unknown names still draw as opaque external references, because a picture of an external type is useful while a _compile_ of one is not.
+
+## Why this matters for drift
+
+[Schema-driven development](https://godspeed.systems/blog/schema-driven-development-and-single-source-of-truth) only pays off if every consumer can build _directly_ from the generated output with zero hand-edits. The two gaps above each forced a hand-edit — patch the `str` back to a `UUID`, or notice the bad type before it shipped — and every hand-edit is a place drift creeps in. Closing them keeps the schema as the one source of truth, all the way down to the timestamp.
+
+## Get it
+
+- **CLI / library:** `npm install -g typediagram` (or `npm i typediagram-core`)
+- **VS Code extension:** [Install from the Marketplace](https://marketplace.visualstudio.com/items?itemName=nimblesite.typediagram)
+- **Try it now:** the [playground](/#playground) and [converter](/converter.html) run entirely in your browser.
+
+Full type-mapping details are in the [Language Reference](/docs/language-reference.html) and [Converters](/docs/converters.html) docs.


### PR DESCRIPTION
## Why
The VS Code Marketplace was stuck at **0.8.0** — releases 0.9.0 and 0.10.0 published to npm + GitHub Releases but **never reached the Marketplace**. The release workflow's publish step was gated on a `VSCE_PAT` secret that isn't configured, and on a missing PAT it printed a message and `exit 0`, so the step went green and the miss was silent for two releases.

## What changed
**`release.yml` — Marketplace publish via Microsoft Entra OIDC, no stored PAT, no silent skip.**
- New `publish-marketplace` job bound to `environment: release` so the GitHub OIDC subject (`repo:Nimblesite/typeDiagram:environment:release`) matches the shared Entra app's wildcard federated credential.
- `azure/login` (OIDC, `allow-no-subscriptions`) → mint a Marketplace-scoped token via `az account get-access-token --resource 499b84ac-…` → `vsce publish` (pinned `@vscode/vsce@3.9.2`, `--skip-duplicate`, `--pre-release` only for `-`-suffixed tags). Follows the Nimblesite/NimblesiteDeployment runbook (which documents that `vsce --azure-credential` is buggy, so we mint the token ourselves).
- The `VSCE_PAT` gate and its `exit 0` are **gone** — any failure now turns the release red.
- Actions SHA-pinned (`azure/login@v2.3.0`, `download-artifact@v4.3.0`).
- Repo onboarded per the runbook: `release` environment + non-secret `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`. Publisher `nimblesite` is already an authorized member via the shared app.

**`ci.yml` — path-selective.** Website/docs-only PRs run a lightweight build + lint + web-unit path and skip the full framework test matrix, bundle-size, Playwright e2e, and Shipwright gates. The single `CI` job always runs/reports, so it stays valid as a required check.

**Docs/site** — DateTime/Uuid/Decimal scalars + strict unknown-type codegen documented across the language reference, converters, CLI, getting-started, and README; a 0.11 release blog post; and a plan doc for the remediation.

## Follow-up
Merge → tag `v0.11.0` → the OIDC job publishes the VSIX as a stable Marketplace release.

