### PR TITLE
Pin @types/vscode to match engines.vscode (fix VSIX packaging)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7450,7 +7450,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.1.0",
         "@types/pdfkit": "^0.17.6",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.99.0",
         "@vscode/test-electron": "^3.0.0",
         "esbuild": "^0.28.1",
         "mocha": "^11.7.6",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -166,7 +166,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.0",
     "@types/pdfkit": "^0.17.6",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.99.0",
     "@vscode/test-electron": "^3.0.0",
     "esbuild": "^0.28.1",
     "mocha": "^11.7.6",


### PR DESCRIPTION
## Summary
The v0.12.0 Release passed the CodeQL gate and **published `typediagram-core@0.12.0` and `typediagram@0.12.0` to npm**, but the `Package VSIX` step failed:

> `@types/vscode ^1.125.0 greater than engines.vscode ^1.99.0`

`@types/vscode` was bumped to `^1.125.0` (dependency update) while `engines.vscode` stayed `^1.99.0`; `vsce package` rejects that mismatch. The extension only uses the 1.99-era API, so this pins `@types/vscode` back to `^1.99.0` — matching the engine floor and restoring the v0.11.0 config that packaged cleanly.

Verified locally: `vscode` typecheck passes and `vsce package` succeeds (18 files, ~1 MB VSIX).

npm publishes are idempotent (already live); after merge I'll re-point `v0.12.0` and the re-run completes VSIX + Marketplace + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)